### PR TITLE
Add bolt 5.4 support (telemetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,49 @@
 # Changelog
 
-## NEXT
+⚠️ marks breaking changes or pending breaking changes (deprecations).
 
-- Removed useless lifetime parameter from `SessionConfig::with_database()`.
-- Changed return type of `ConnectionConfig::with_encryption_trust_any_certificate() ` from `Result<Self, Error>`
-  to `Self`.
+## NEXT
+***
+**⭐ New Features**
 - Add support for Bolt 5.2, which adds notification filtering.
-- Add `Driver::is_encrypted()`.
-- Reduce the number of lifetime generic parameters in `TransactionQueryBuilder` and `TransactionRecordStream`.
-- Fix `Transaction::rolblack()` failing if a result stream failed before.
-- Introduce `neo4j::driver::Conifg::with_keep_alive()` and `without_keep_alive()`.
-- Fix errors during transaction `BEGIN` not being properly propagated.
-- Fix propagation of `is_retryable()` of errors within transactions.
 - Add support for Bolt 5.3 (bolt agent).
 - Add support for Bolt 5.4 (telemetry).
+- Add `Driver::is_encrypted()`.
+- Introduce `neo4j::driver::Conifg::with_keep_alive()` and `without_keep_alive()`.
+
+**🔧 Fixes**
+- Fix `Transaction::rolblack()` failing if a result stream failed before.
+- Fix errors during transaction `BEGIN` not being properly propagated.
+- Fix propagation of `is_retryable()` of errors within transactions.
+
+**🧹Clean-up**
+- ⚠️ Removed useless lifetime parameter from `SessionConfig::with_database()`.
+- ⚠️ Changed return type of `ConnectionConfig::with_encryption_trust_any_certificate() ` from `Result<Self, Error>` to `Self`.
+- ⚠️ Reduce the number of lifetime generic parameters in `TransactionQueryBuilder` and `TransactionRecordStream`.
+
 
 ## 0.0.2
+***
+**👏 Improvements**
+- Impl `FromStr` for `neo4j::driver::ConnectionConfig` (besides `TryFrom<&str>`).
 
-- Update dependencies.  
+- **🧹Clean-up**
+- ⚠️ Update dependencies.  
   Among others `rustls`.
   To accommodate this change, the `rustls_dangerous_configuration` feature was removed.
   This update also affects `ConnectionConfig::with_encryption_custom_tls_config()`, which accepts a
   custom `rustls::ClientConfig`.
-- Make `Record{entries}` private and offer many helper methods instead.
+- ⚠️ Make `Record{entries}` private and offer many helper methods instead.
 - Add `EagerResult::into_scalar()`.
-- Renamed `RetryableError` to `RetryError`
+- ⚠️ Renamed `RetryableError` to `RetryError`
 - Fix `Driver::execute_query()::run()` not committing the transaction.
-- Removed `AutoCommitBuilder::without_transaction_timeout` and `AutoCommitBuilder::with_default_transaction_timeout`
+- ⚠️ Removed `AutoCommitBuilder::without_transaction_timeout` and `AutoCommitBuilder::with_default_transaction_timeout`
   in favor of `AutoCommitBuilder::with_transaction_timeout` in combination with `TransactionTimeout::none`,
   `TransactionTimeout::from_millis` and `TransactionTimeout::default`.  
   Same for `TransactionBuilder`.
-- Move `neo4j::Address` to `neo4j::address::Address`
-- Impl `FromStr` for `neo4j::driver::ConnectionConfig` (besides `TryFrom<&str>`).
+- ⚠️ Move `neo4j::Address` to `neo4j::address::Address`
+
+**📚 Docs**
 - Much more documentation.
 
 ## 0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix `Transaction::rolblack()` failing if a result stream failed before.
 - Fix errors during transaction `BEGIN` not being properly propagated.
 - Fix propagation of `is_retryable()` of errors within transactions.
+- Fix connection hint `connection.recv_timeout_seconds` not always being respected leading to connections timeing out too late.
 
 **🧹Clean-up**
 - ⚠️ Removed useless lifetime parameter from `SessionConfig::with_database()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,38 @@
 # Changelog
 
 ## NEXT
- - Removed useless lifetime parameter from `SessionConfig::with_database()`.
- - Changed return type of `ConnectionConfig::with_encryption_trust_any_certificate() ` from `Result<Self, Error>` to `Self`.
- - Add support for Bolt 5.2, which adds notification filtering.
- - Add `Driver::is_encrypted()`.
- - Reduce the number of lifetime generic parameters in `TransactionQueryBuilder` and `TransactionRecordStream`.
- - Fix `Transaction::rolblack()` failing if a result stream failed before.
- - Introduce `neo4j::driver::Conifg::with_keep_alive()` and `without_keep_alive()`.
- - Add support for Bolt 5.3 (bolt agent).
+
+- Removed useless lifetime parameter from `SessionConfig::with_database()`.
+- Changed return type of `ConnectionConfig::with_encryption_trust_any_certificate() ` from `Result<Self, Error>`
+  to `Self`.
+- Add support for Bolt 5.2, which adds notification filtering.
+- Add `Driver::is_encrypted()`.
+- Reduce the number of lifetime generic parameters in `TransactionQueryBuilder` and `TransactionRecordStream`.
+- Fix `Transaction::rolblack()` failing if a result stream failed before.
+- Introduce `neo4j::driver::Conifg::with_keep_alive()` and `without_keep_alive()`.
+- Fixed errors during `BEGIN` not being properly propagated through the transaction's internals.
+- Add support for Bolt 5.3 (bolt agent).
+- Add support for Bolt 5.4 (telemetry).
 
 ## 0.0.2
- - Update dependencies.  
-   Among others `rustls`.
-   To accommodate this change, the `rustls_dangerous_configuration` feature was removed.
-   This update also affects `ConnectionConfig::with_encryption_custom_tls_config()`, which accepts a custom `rustls::ClientConfig`.
- - Make `Record{entries}` private and offer many helper methods instead.
- - Add `EagerResult::into_scalar()`.
- - Renamed `RetryableError` to `RetryError`
- - Fix `Driver::execute_query()::run()` not committing the transaction.
- - Removed `AutoCommitBuilder::without_transaction_timeout` and `AutoCommitBuilder::with_default_transaction_timeout`
-   in favor of `AutoCommitBuilder::with_transaction_timeout` in combination with `TransactionTimeout::none`,
-   `TransactionTimeout::from_millis` and `TransactionTimeout::default`.  
-   Same for `TransactionBuilder`.
- - Move `neo4j::Address` to `neo4j::address::Address`
- - Impl `FromStr` for `neo4j::driver::ConnectionConfig` (besides `TryFrom<&str>`).
- - Much more documentation.
+
+- Update dependencies.  
+  Among others `rustls`.
+  To accommodate this change, the `rustls_dangerous_configuration` feature was removed.
+  This update also affects `ConnectionConfig::with_encryption_custom_tls_config()`, which accepts a
+  custom `rustls::ClientConfig`.
+- Make `Record{entries}` private and offer many helper methods instead.
+- Add `EagerResult::into_scalar()`.
+- Renamed `RetryableError` to `RetryError`
+- Fix `Driver::execute_query()::run()` not committing the transaction.
+- Removed `AutoCommitBuilder::without_transaction_timeout` and `AutoCommitBuilder::with_default_transaction_timeout`
+  in favor of `AutoCommitBuilder::with_transaction_timeout` in combination with `TransactionTimeout::none`,
+  `TransactionTimeout::from_millis` and `TransactionTimeout::default`.  
+  Same for `TransactionBuilder`.
+- Move `neo4j::Address` to `neo4j::address::Address`
+- Impl `FromStr` for `neo4j::driver::ConnectionConfig` (besides `TryFrom<&str>`).
+- Much more documentation.
 
 ## 0.0.1
+
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Reduce the number of lifetime generic parameters in `TransactionQueryBuilder` and `TransactionRecordStream`.
 - Fix `Transaction::rolblack()` failing if a result stream failed before.
 - Introduce `neo4j::driver::Conifg::with_keep_alive()` and `without_keep_alive()`.
-- Fixed errors during transaction `BEGIN` not being properly propagated.
+- Fix errors during transaction `BEGIN` not being properly propagated.
+- Fix propagation of `is_retryable()` of errors within transactions.
 - Add support for Bolt 5.3 (bolt agent).
 - Add support for Bolt 5.4 (telemetry).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Reduce the number of lifetime generic parameters in `TransactionQueryBuilder` and `TransactionRecordStream`.
 - Fix `Transaction::rolblack()` failing if a result stream failed before.
 - Introduce `neo4j::driver::Conifg::with_keep_alive()` and `without_keep_alive()`.
-- Fixed errors during `BEGIN` not being properly propagated through the transaction's internals.
+- Fixed errors during transaction `BEGIN` not being properly propagated.
 - Add support for Bolt 5.3 (bolt agent).
 - Add support for Bolt 5.4 (telemetry).
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ A bump in MSRV is considered a minor breaking change.
      * [x] most basic functionality
      * [ ] ergonomic way to access by key
  * [x] Bookmark Management
- * [ ] Protocol Versions
+ * [x] Protocol Versions
    * [x] 4.4
    * [x] 5.0 (utc fix)
    * [x] 5.1 (re-auth)
    * [x] 5.2 (notification filtering)
    * [x] 5.3 (bolt agent)
-   * [ ] 5.4 (telemetry)
+   * [x] 5.4 (telemetry)
  * [x] Types
    * [x] `Null`
    * [x] `Integer`

--- a/neo4j/src/driver/config.rs
+++ b/neo4j/src/driver/config.rs
@@ -37,7 +37,7 @@ use notification::NotificationFilter;
 
 // imports for docs
 #[allow(unused)]
-use super::session::SessionConfig;
+use super::session::{AutoCommitBuilder, SessionConfig, TransactionBuilder};
 #[allow(unused)]
 use super::ExecuteQueryBuilder;
 #[allow(unused)]
@@ -63,6 +63,7 @@ pub struct DriverConfig {
     pub(crate) resolver: Option<Box<dyn AddressResolver>>,
     pub(crate) notification_filter: NotificationFilter,
     pub(crate) keep_alive: Option<KeepAliveConfig>,
+    pub(crate) telemetry: bool,
 }
 
 #[derive(Debug)]
@@ -155,6 +156,7 @@ impl Default for DriverConfig {
             resolver: None,
             notification_filter: Default::default(),
             keep_alive: None,
+            telemetry: true,
         }
     }
 }
@@ -530,6 +532,31 @@ impl DriverConfig {
     #[inline]
     pub fn without_keep_alive(mut self) -> Self {
         self.keep_alive = None;
+        self
+    }
+
+    /// Enable or disable telemetry.
+    ///
+    /// If enabled (default) and the server requests is, the driver will send anonymous API usage
+    /// statistics to the server.
+    /// Currently, everytime one of the following APIs is used to execute a query
+    /// (for the first time), the server is informed of this
+    /// (without any further information like arguments, client identifiers, etc.):
+    ///
+    /// * [`ExecuteQueryBuilder::run()`] / [`ExecuteQueryBuilder::run_with_retry()`]
+    /// * [`TransactionBuilder::run()`]
+    /// * [`TransactionBuilder::run_with_retry()`]
+    /// * [`AutoCommitBuilder::run()`]
+    ///
+    /// # Example
+    /// ```
+    /// use neo4j::driver::DriverConfig;
+    ///
+    /// let config = DriverConfig::new().with_telemetry(false);
+    /// ```
+    #[inline]
+    pub fn with_telemetry(mut self, telemetry: bool) -> Self {
+        self.telemetry = telemetry;
         self
     }
 }

--- a/neo4j/src/driver/io/bolt/bolt4x4/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt4x4/protocol.rs
@@ -30,7 +30,7 @@ use super::super::message::BoltMessage;
 use super::super::message_parameters::{
     BeginParameters, CommitParameters, DiscardParameters, GoodbyeParameters, HelloParameters,
     PullParameters, ReauthParameters, ResetParameters, RollbackParameters, RouteParameters,
-    RunParameters,
+    RunParameters, TelemetryParameters,
 };
 use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
@@ -267,8 +267,9 @@ impl<T: BoltStructTranslatorWithUtcPatch + Sync + Send + 'static> BoltProtocol f
         &mut self,
         data: &mut BoltData<RW>,
         parameters: BeginParameters<K>,
+        callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x0.begin(data, parameters)
+        self.bolt5x0.begin(data, parameters, callbacks)
     }
 
     #[inline]
@@ -298,6 +299,16 @@ impl<T: BoltStructTranslatorWithUtcPatch + Sync + Send + 'static> BoltProtocol f
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
         self.bolt5x0.route(data, parameters, callbacks)
+    }
+
+    #[inline]
+    fn telemetry<RW: Read + Write>(
+        &mut self,
+        data: &mut BoltData<RW>,
+        parameters: TelemetryParameters,
+        callbacks: ResponseCallbacks,
+    ) -> Result<()> {
+        self.bolt5x0.telemetry(data, parameters, callbacks)
     }
 
     fn load_value<R: Read>(&mut self, reader: &mut R) -> Result<ValueReceive> {

--- a/neo4j/src/driver/io/bolt/bolt5x0/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x0/protocol.rs
@@ -31,7 +31,7 @@ use super::super::message::BoltMessage;
 use super::super::message_parameters::{
     BeginParameters, CommitParameters, DiscardParameters, GoodbyeParameters, HelloParameters,
     PullParameters, ReauthParameters, ResetParameters, RollbackParameters, RouteParameters,
-    RunParameters,
+    RunParameters, TelemetryParameters,
 };
 use super::super::packstream::{
     PackStreamDeserializer, PackStreamDeserializerImpl, PackStreamSerializer,
@@ -772,6 +772,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x0<T> {
         &mut self,
         data: &mut BoltData<RW>,
         parameters: BeginParameters<K>,
+        callbacks: ResponseCallbacks,
     ) -> Result<()> {
         let BeginParameters {
             bookmarks,
@@ -844,7 +845,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x0<T> {
 
         data.message_buff.push_back(vec![message_buff]);
         data.responses
-            .push_back(BoltResponse::from_message(ResponseMessage::Begin));
+            .push_back(BoltResponse::new(ResponseMessage::Begin, callbacks));
         debug_buf_end!(data, log_buf);
         Ok(())
     }
@@ -939,6 +940,17 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x0<T> {
         data.responses
             .push_back(BoltResponse::new(ResponseMessage::Route, callbacks));
         debug_buf_end!(data, log_buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn telemetry<RW: Read + Write>(
+        &mut self,
+        _data: &mut BoltData<RW>,
+        _parameters: TelemetryParameters,
+        _callbacks: ResponseCallbacks,
+    ) -> Result<()> {
+        // TELEMETRY not support by this protocol version, so we ignore it.
         Ok(())
     }
 

--- a/neo4j/src/driver/io/bolt/bolt5x1/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x1/protocol.rs
@@ -26,7 +26,7 @@ use super::super::message::BoltMessage;
 use super::super::message_parameters::{
     BeginParameters, CommitParameters, DiscardParameters, GoodbyeParameters, HelloParameters,
     PullParameters, ReauthParameters, ResetParameters, RollbackParameters, RouteParameters,
-    RunParameters,
+    RunParameters, TelemetryParameters,
 };
 use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
@@ -266,8 +266,9 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x1<T> {
         &mut self,
         data: &mut BoltData<RW>,
         parameters: BeginParameters<K>,
+        callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x0.begin(data, parameters)
+        self.bolt5x0.begin(data, parameters, callbacks)
     }
 
     #[inline]
@@ -297,6 +298,16 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x1<T> {
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
         self.bolt5x0.route(data, parameters, callbacks)
+    }
+
+    #[inline]
+    fn telemetry<RW: Read + Write>(
+        &mut self,
+        data: &mut BoltData<RW>,
+        parameters: TelemetryParameters,
+        callbacks: ResponseCallbacks,
+    ) -> Result<()> {
+        self.bolt5x0.telemetry(data, parameters, callbacks)
     }
 
     #[inline]

--- a/neo4j/src/driver/io/bolt/bolt5x2/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x2/protocol.rs
@@ -27,7 +27,7 @@ use super::super::message::BoltMessage;
 use super::super::message_parameters::{
     BeginParameters, CommitParameters, DiscardParameters, GoodbyeParameters, HelloParameters,
     PullParameters, ReauthParameters, ResetParameters, RollbackParameters, RouteParameters,
-    RunParameters,
+    RunParameters, TelemetryParameters,
 };
 use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
@@ -356,6 +356,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x2<T> {
         &mut self,
         data: &mut BoltData<RW>,
         parameters: BeginParameters<K>,
+        callbacks: ResponseCallbacks,
     ) -> Result<()> {
         let BeginParameters {
             bookmarks,
@@ -467,7 +468,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x2<T> {
 
         data.message_buff.push_back(vec![message_buff]);
         data.responses
-            .push_back(BoltResponse::from_message(ResponseMessage::Begin));
+            .push_back(BoltResponse::new(ResponseMessage::Begin, callbacks));
         debug_buf_end!(data, log_buf);
         Ok(())
     }
@@ -499,6 +500,16 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x2<T> {
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
         self.bolt5x1.route(data, parameters, callbacks)
+    }
+
+    #[inline]
+    fn telemetry<RW: Read + Write>(
+        &mut self,
+        data: &mut BoltData<RW>,
+        parameters: TelemetryParameters,
+        callbacks: ResponseCallbacks,
+    ) -> Result<()> {
+        self.bolt5x1.telemetry(data, parameters, callbacks)
     }
 
     #[inline]

--- a/neo4j/src/driver/io/bolt/bolt5x4.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x4.rs
@@ -1,0 +1,19 @@
+// Copyright Rouven Bauer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod protocol;
+mod translator;
+
+pub(crate) use protocol::Bolt5x4;
+pub(crate) use translator::Bolt5x4StructTranslator;

--- a/neo4j/src/driver/io/bolt/bolt5x4/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x4/protocol.rs
@@ -12,30 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use atomic_refcell::AtomicRefCell;
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::{Read, Write};
+use std::mem;
+use std::net::TcpStream;
+use std::ops::Deref;
+use std::sync::Arc;
 
-use log::{debug, log_enabled, Level};
+use log::{debug, log_enabled, warn, Level};
 
 use super::super::bolt5x0::Bolt5x0;
 use super::super::bolt5x2::Bolt5x2;
-use super::super::bolt_common::{
-    ServerAwareBoltVersion, BOLT_AGENT_LANGUAGE, BOLT_AGENT_LANGUAGE_DETAILS, BOLT_AGENT_PLATFORM,
-    BOLT_AGENT_PRODUCT,
-};
+use super::super::bolt5x3::Bolt5x3;
+use super::super::bolt_common::ServerAwareBoltVersion;
 use super::super::message::BoltMessage;
 use super::super::message_parameters::{
     BeginParameters, CommitParameters, DiscardParameters, GoodbyeParameters, HelloParameters,
     PullParameters, ReauthParameters, ResetParameters, RollbackParameters, RouteParameters,
-    RunParameters, TelemetryParameters,
+    RunParameters, TelemetryAPI, TelemetryParameters,
 };
 use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
 use super::super::{
-    bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol,
-    BoltStructTranslator, OnServerErrorCb, ResponseCallbacks,
+    bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltMeta,
+    BoltProtocol, BoltResponse, BoltStructTranslator, OnServerErrorCb, ResponseCallbacks,
+    ResponseMessage,
 };
 use crate::error_::Result;
 use crate::value::ValueReceive;
@@ -43,64 +48,104 @@ use crate::value::ValueReceive;
 const SERVER_AGENT_KEY: &str = "server";
 const HINTS_KEY: &str = "hints";
 const RECV_TIMEOUT_KEY: &str = "connection.recv_timeout_seconds";
+const TELEMETRY_ENABLED_KEY: &str = "telemetry.enabled";
 
 #[derive(Debug)]
-pub(crate) struct Bolt5x3<T: BoltStructTranslator> {
+pub(crate) struct Bolt5x4<T: BoltStructTranslator> {
     translator: T,
-    pub(in super::super) bolt5x2: Bolt5x2<T>,
+    pub(in super::super) bolt5x3: Bolt5x3<T>,
     protocol_version: ServerAwareBoltVersion,
 }
 
-impl<T: BoltStructTranslator> Bolt5x3<T> {
+impl<T: BoltStructTranslator> Bolt5x4<T> {
     pub(in super::super) fn new(protocol_version: ServerAwareBoltVersion) -> Self {
         Self {
             translator: T::default(),
-            bolt5x2: Bolt5x2::new(protocol_version),
+            bolt5x3: Bolt5x3::new(protocol_version),
             protocol_version,
         }
     }
 
-    pub(in super::super) fn write_bolt_agent_entry(
-        mut log_buf: Option<&mut String>,
-        serializer: &mut PackStreamSerializerImpl<impl Write>,
-        dbg_serializer: &mut PackStreamSerializerDebugImpl,
-    ) -> Result<()> {
-        serializer.write_string("bolt_agent")?;
-        serializer.write_dict_header(4)?;
-        serializer.write_string("product")?;
-        serializer.write_string(BOLT_AGENT_PRODUCT)?;
-        serializer.write_string("platform")?;
-        serializer.write_string(BOLT_AGENT_PLATFORM)?;
-        serializer.write_string("language")?;
-        serializer.write_string(BOLT_AGENT_LANGUAGE)?;
-        serializer.write_string("language_details")?;
-        serializer.write_string(BOLT_AGENT_LANGUAGE_DETAILS)?;
-        debug_buf!(log_buf, " {}", {
-            dbg_serializer.write_string("bolt_agent").unwrap();
-            dbg_serializer.write_dict_header(4).unwrap();
-            dbg_serializer.write_string("product").unwrap();
-            dbg_serializer.write_string(BOLT_AGENT_PRODUCT).unwrap();
-            dbg_serializer.write_string("platform").unwrap();
-            dbg_serializer.write_string(BOLT_AGENT_PLATFORM).unwrap();
-            dbg_serializer.write_string("language").unwrap();
-            dbg_serializer.write_string(BOLT_AGENT_LANGUAGE).unwrap();
-            dbg_serializer.write_string("language_details").unwrap();
-            dbg_serializer
-                .write_string(BOLT_AGENT_LANGUAGE_DETAILS)
-                .unwrap();
-            dbg_serializer.flush()
-        });
-        Ok(())
+    pub(in super::super) fn hello_response_telemetry_hint(
+        hints: &HashMap<String, ValueReceive>,
+        telemetry_enabled: &mut bool,
+    ) {
+        if !*telemetry_enabled {
+            // driver config opted out of telemetry
+            return;
+        }
+        let Some(enabled) = hints.get(TELEMETRY_ENABLED_KEY) else {
+            // server implicitly opted out of telemetry
+            *telemetry_enabled = false;
+            return;
+        };
+        let ValueReceive::Boolean(enabled) = enabled else {
+            warn!(
+                "Server sent unexpected {TELEMETRY_ENABLED_KEY} type {:?}",
+                enabled
+            );
+            return;
+        };
+        // since client didn't opt out, leave it up to the server
+        *telemetry_enabled = *enabled;
+    }
+
+    pub(in super::super) fn hello_response_handle_connection_hints(
+        meta: &BoltMeta,
+        socket: Option<&TcpStream>,
+        telemetry_enabled: &mut bool,
+    ) {
+        let empty_hints = HashMap::new();
+        let hints = match meta.get(HINTS_KEY) {
+            Some(ValueReceive::Map(hints)) => hints,
+            Some(value) => {
+                warn!("Server sent unexpected {HINTS_KEY} type {:?}", value);
+                &empty_hints
+            }
+            None => &empty_hints,
+        };
+        Bolt5x0::<T>::hello_response_handle_timeout_hint(hints, socket);
+        Self::hello_response_telemetry_hint(hints, telemetry_enabled);
+    }
+
+    pub(in super::super) fn enqueue_hello_response(data: &mut BoltData<impl Read + Write>) {
+        let bolt_meta = Arc::clone(&data.meta);
+        let telemetry_enabled = Arc::clone(&data.telemetry_enabled);
+        let bolt_server_agent = Arc::clone(&data.server_agent);
+        let socket = Arc::clone(&data.socket);
+
+        data.responses.push_back(BoltResponse::new(
+            ResponseMessage::Hello,
+            ResponseCallbacks::new().with_on_success(move |mut meta| {
+                Bolt5x0::<T>::hello_response_handle_agent(&mut meta, &bolt_server_agent);
+                Self::hello_response_handle_connection_hints(
+                    &meta,
+                    socket.deref().as_ref(),
+                    &mut telemetry_enabled.borrow_mut(),
+                );
+                mem::swap(&mut *bolt_meta.borrow_mut(), &mut meta);
+                Ok(())
+            }),
+        ));
+    }
+
+    pub(in super::super) fn encode_telemetry(api: TelemetryAPI) -> i64 {
+        match api {
+            TelemetryAPI::TxFunc => 0,
+            TelemetryAPI::UnmanagedTx => 1,
+            TelemetryAPI::AutoCommit => 2,
+            TelemetryAPI::DriverLevel => 3,
+        }
     }
 }
 
-impl<T: BoltStructTranslator> Default for Bolt5x3<T> {
+impl<T: BoltStructTranslator> Default for Bolt5x4<T> {
     fn default() -> Self {
-        Self::new(ServerAwareBoltVersion::V5x3)
+        Self::new(ServerAwareBoltVersion::V5x4)
     }
 }
 
-impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
+impl<T: BoltStructTranslator> BoltProtocol for Bolt5x4<T> {
     fn hello<RW: Read + Write>(
         &mut self,
         data: &mut BoltData<RW>,
@@ -136,15 +181,23 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
             user_agent,
         )?;
 
-        Self::write_bolt_agent_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer)?;
-
-        self.bolt5x2.bolt5x1.bolt5x0.write_routing_context_entry(
+        Bolt5x3::<T>::write_bolt_agent_entry(
             log_buf.as_mut(),
             &mut serializer,
             &mut dbg_serializer,
-            data,
-            routing_context,
         )?;
+
+        self.bolt5x3
+            .bolt5x2
+            .bolt5x1
+            .bolt5x0
+            .write_routing_context_entry(
+                log_buf.as_mut(),
+                &mut serializer,
+                &mut dbg_serializer,
+                data,
+                routing_context,
+            )?;
 
         Bolt5x2::<T>::write_notification_filter_entries(
             log_buf.as_mut(),
@@ -156,7 +209,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data.message_buff.push_back(vec![message_buff]);
         debug_buf_end!(data, log_buf);
 
-        Bolt5x0::<T>::enqueue_hello_response(data);
+        Self::enqueue_hello_response(data);
         Ok(())
     }
 
@@ -166,12 +219,12 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: ReauthParameters,
     ) -> Result<()> {
-        self.bolt5x2.reauth(data, parameters)
+        self.bolt5x3.reauth(data, parameters)
     }
 
     #[inline]
     fn supports_reauth(&self) -> bool {
-        self.bolt5x2.supports_reauth()
+        self.bolt5x3.supports_reauth()
     }
 
     #[inline]
@@ -180,7 +233,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: GoodbyeParameters,
     ) -> Result<()> {
-        self.bolt5x2.goodbye(data, parameters)
+        self.bolt5x3.goodbye(data, parameters)
     }
 
     #[inline]
@@ -189,7 +242,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: ResetParameters,
     ) -> Result<()> {
-        self.bolt5x2.reset(data, parameters)
+        self.bolt5x3.reset(data, parameters)
     }
 
     #[inline]
@@ -199,7 +252,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: RunParameters<KP, KM>,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.run(data, parameters, callbacks)
+        self.bolt5x3.run(data, parameters, callbacks)
     }
 
     #[inline]
@@ -209,7 +262,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: DiscardParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.discard(data, parameters, callbacks)
+        self.bolt5x3.discard(data, parameters, callbacks)
     }
 
     #[inline]
@@ -219,7 +272,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: PullParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.pull(data, parameters, callbacks)
+        self.bolt5x3.pull(data, parameters, callbacks)
     }
 
     #[inline]
@@ -229,7 +282,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: BeginParameters<K>,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.begin(data, parameters, callbacks)
+        self.bolt5x3.begin(data, parameters, callbacks)
     }
 
     #[inline]
@@ -239,7 +292,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: CommitParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.commit(data, parameters, callbacks)
+        self.bolt5x3.commit(data, parameters, callbacks)
     }
 
     #[inline]
@@ -248,7 +301,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: RollbackParameters,
     ) -> Result<()> {
-        self.bolt5x2.rollback(data, parameters)
+        self.bolt5x3.rollback(data, parameters)
     }
 
     #[inline]
@@ -258,22 +311,50 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: RouteParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.route(data, parameters, callbacks)
+        self.bolt5x3.route(data, parameters, callbacks)
     }
 
-    #[inline]
     fn telemetry<RW: Read + Write>(
         &mut self,
         data: &mut BoltData<RW>,
         parameters: TelemetryParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.telemetry(data, parameters, callbacks)
+        if !AtomicRefCell::borrow(&data.telemetry_enabled).deref() {
+            return Ok(());
+        }
+
+        let TelemetryParameters { api } = parameters;
+        debug_buf_start!(log_buf);
+        debug_buf!(log_buf, "C: TELEMETRY");
+        let mut dbg_serializer = PackStreamSerializerDebugImpl::new();
+        let mut message_buff = Vec::new();
+        let mut serializer = PackStreamSerializerImpl::new(&mut message_buff);
+        serializer.write_struct_header(0x54, 1)?;
+
+        serializer.write_int(Self::encode_telemetry(api))?;
+        debug_buf!(
+            log_buf,
+            " {} // ({})",
+            {
+                dbg_serializer
+                    .write_int(Self::encode_telemetry(api))
+                    .unwrap();
+                dbg_serializer.flush()
+            },
+            api.name()
+        );
+
+        data.message_buff.push_back(vec![message_buff]);
+        debug_buf_end!(data, log_buf);
+        data.responses
+            .push_back(BoltResponse::new(ResponseMessage::Telemetry, callbacks));
+        Ok(())
     }
 
     #[inline]
     fn load_value<R: Read>(&mut self, reader: &mut R) -> Result<ValueReceive> {
-        self.bolt5x2.load_value(reader)
+        self.bolt5x3.load_value(reader)
     }
 
     #[inline]
@@ -283,7 +364,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         message: BoltMessage<ValueReceive>,
         on_server_error: OnServerErrorCb<RW>,
     ) -> Result<()> {
-        self.bolt5x2
+        self.bolt5x3
             .handle_response(bolt_data, message, on_server_error)
     }
 }

--- a/neo4j/src/driver/io/bolt/bolt5x4/translator.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x4/translator.rs
@@ -1,0 +1,17 @@
+// Copyright Rouven Bauer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::bolt5x3::Bolt5x3StructTranslator;
+
+pub(crate) type Bolt5x4StructTranslator = Bolt5x3StructTranslator;

--- a/neo4j/src/driver/io/bolt/bolt_state.rs
+++ b/neo4j/src/driver/io/bolt/bolt_state.rs
@@ -81,6 +81,7 @@ impl BoltStateTracker {
             ResponseMessage::Commit => self.update_commit(),
             ResponseMessage::Rollback => self.update_rollback(),
             ResponseMessage::Route => self.update_route(),
+            ResponseMessage::Telemetry => {} // no state transition
         }
 
         if self.state != pre_state {

--- a/neo4j/src/driver/io/bolt/handshake.rs
+++ b/neo4j/src/driver/io/bolt/handshake.rs
@@ -34,7 +34,7 @@ use crate::time::Instant;
 const BOLT_MAGIC_PREAMBLE: [u8; 4] = [0x60, 0x60, 0xB0, 0x17];
 // [bolt-version-bump] search tag when changing bolt version support
 const BOLT_VERSION_OFFER: [u8; 16] = [
-    0, 3, 3, 5, // BOLT 5.3 - 5.0
+    0, 4, 4, 5, // BOLT 5.4 - 5.0
     0, 0, 4, 4, // BOLT 4.4
     0, 0, 0, 0, // -
     0, 0, 0, 0, // -
@@ -243,6 +243,7 @@ fn decode_version_offer(offer: &[u8; 4]) -> Result<(u8, u8)> {
         [0, 0, 0, 0] => Err(Neo4jError::InvalidConfig {
             message: String::from("server version not supported"),
         }),
+        [_, _, 4, 5] => Ok((5, 4)),
         [_, _, 3, 5] => Ok((5, 3)),
         [_, _, 2, 5] => Ok((5, 2)),
         [_, _, 1, 5] => Ok((5, 1)),
@@ -356,6 +357,7 @@ mod tests {
     #[case([0, 0, 1, 5], (5, 1))]
     #[case([0, 0, 2, 5], (5, 2))]
     #[case([0, 0, 3, 5], (5, 3))]
+    #[case([0, 0, 4, 5], (5, 4))]
     fn test_decode_version_offer(
         #[case] mut offer: [u8; 4],
         #[case] expected: (u8, u8),
@@ -395,7 +397,7 @@ mod tests {
     #[case([0, 0, 1, 4])] // driver didn't offer version 4.1
     #[case([0, 0, 2, 4])] // driver didn't offer version 4.2
     #[case([0, 0, 3, 4])] // driver didn't offer version 4.3
-    #[case([0, 0, 4, 5])] // driver didn't offer version 5.4
+    #[case([0, 0, 5, 5])] // driver didn't offer version 5.4
     #[case([0, 0, 0, 6])] // driver didn't offer version 6.0
     fn test_garbage_server_version(
         #[case] mut offer: [u8; 4],

--- a/neo4j/src/driver/io/bolt/message_parameters.rs
+++ b/neo4j/src/driver/io/bolt/message_parameters.rs
@@ -233,3 +233,33 @@ impl<'a> RouteParameters<'a> {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TelemetryAPI {
+    TxFunc,
+    UnmanagedTx,
+    AutoCommit,
+    DriverLevel,
+}
+
+impl TelemetryAPI {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::TxFunc => "Session::transaction with retry",
+            Self::UnmanagedTx => "Session::transaction without retry",
+            Self::AutoCommit => "Session::auto_commit",
+            Self::DriverLevel => "Driver::execute_query",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TelemetryParameters {
+    pub(super) api: TelemetryAPI,
+}
+
+impl TelemetryParameters {
+    pub(crate) fn new(api: TelemetryAPI) -> Self {
+        Self { api }
+    }
+}

--- a/neo4j/src/driver/io/bolt/response.rs
+++ b/neo4j/src/driver/io/bolt/response.rs
@@ -31,6 +31,7 @@ pub(crate) enum ResponseMessage {
     Commit,
     Rollback,
     Route,
+    Telemetry,
 }
 
 #[derive(Debug)]

--- a/neo4j/src/driver/io/deadline.rs
+++ b/neo4j/src/driver/io/deadline.rs
@@ -121,6 +121,12 @@ impl<'tcp, S: Read + Write> DeadlineIO<'tcp, S> {
             // deadline in the future
             Some(timeout) => timeout,
         };
+        if let Some(old_timeout) = old_timeout {
+            if timeout >= old_timeout {
+                let res = work(self);
+                return self.wrap_io_error(res, ReaderErrorDuring::IO);
+            }
+        }
         self.wrap_io_error(
             set_socket_timeout(socket, Some(timeout)),
             ReaderErrorDuring::SetTimeout,

--- a/neo4j/src/driver/io/pool.rs
+++ b/neo4j/src/driver/io/pool.rs
@@ -159,6 +159,7 @@ pub(crate) struct PoolConfig {
     pub(crate) connection_acquisition_timeout: Option<Duration>,
     pub(crate) resolver: Option<Box<dyn AddressResolver>>,
     pub(crate) notification_filters: Arc<NotificationFilter>,
+    pub(crate) telemetry: bool,
 }
 
 impl PoolConfig {

--- a/neo4j/src/driver/io/pool/single_pool.rs
+++ b/neo4j/src/driver/io/pool/single_pool.rs
@@ -102,6 +102,7 @@ impl InnerPool {
 
         let address = Arc::clone(&self.address);
         let mut connection = self.open_socket(address, deadline)?;
+        connection.set_telemetry_enabled(self.config.telemetry);
 
         connection.hello(HelloParameters::new(
             &self.config.user_agent,

--- a/neo4j/src/driver/transaction.rs
+++ b/neo4j/src/driver/transaction.rs
@@ -188,6 +188,7 @@ impl<'driver> InnerTransaction<'driver> {
         if eager {
             cx.write_all(None)?;
             cx.read_all(None)?;
+            self.check_error()?;
         }
         Ok(())
     }

--- a/neo4j/src/driver/transaction.rs
+++ b/neo4j/src/driver/transaction.rs
@@ -30,7 +30,7 @@ use super::io::bolt::ResponseCallbacks;
 use super::io::PooledBolt;
 use super::record_stream::{GetSingleRecordError, RecordStream, SharedErrorPropagator};
 use super::Record;
-use crate::error_::{Neo4jError, Result, ServerError};
+use crate::error_::{Neo4jError, Result};
 use crate::summary::Summary;
 use crate::value::{ValueReceive, ValueSend};
 
@@ -256,9 +256,7 @@ impl<'driver> InnerTransaction<'driver> {
     fn check_error(&self) -> Result<()> {
         match self.error_propagator.deref().borrow().error() {
             None => Ok(()),
-            Some(err) => {
-                Err(ServerError::new(String::from(err.code()), String::from(err.message())).into())
-            }
+            Some(err) => Err(err.deref().clone().into()),
         }
     }
 }

--- a/neo4j/src/error_.rs
+++ b/neo4j/src/error_.rs
@@ -350,6 +350,22 @@ impl ServerError {
     pub(crate) fn overwrite_retryable(&mut self) {
         self.retryable_overwrite = true;
     }
+
+    pub(crate) fn clone(&self) -> Self {
+        Self {
+            code: self.code.clone(),
+            message: self.message.clone(),
+            retryable_overwrite: self.retryable_overwrite,
+        }
+    }
+
+    pub(crate) fn clone_with_reason(&self, reason: &str) -> Self {
+        Self {
+            code: self.code.clone(),
+            message: format!("{}: {}", reason, self.message),
+            retryable_overwrite: self.retryable_overwrite,
+        }
+    }
 }
 
 impl Display for ServerError {

--- a/neo4j/src/lib.rs
+++ b/neo4j/src/lib.rs
@@ -25,10 +25,10 @@
 //!
 //! ## Compatibility
 // [bolt-version-bump] search tag when changing bolt version support
-//! This driver supports bolt protocol version 4.4, and 5.0 - 5.3.
-//! This corresponds to Neo4j versions 4.4, and 5.0 - 5.13.
-//! Newer 5.x versions of the server are able to negotiate a lower, common protocol version.
-//! Therefore, they, too, can be connected to but some features may be available though this driver.
+//! This driver supports bolt protocol version 4.4, and 5.0 - 5.4.
+//! This corresponds to Neo4j versions 4.4, and 5.0 - 5.19+.
+//! For details of bolt protocol compatibility, see the
+//! [official Neo4j documentation](https://neo4j.com/docs/bolt/current/bolt-compatibility/).
 //!
 //! ## Basic Example
 //! ```

--- a/testkit_backend/src/logging.rs
+++ b/testkit_backend/src/logging.rs
@@ -15,7 +15,9 @@
 use std::io::{self, Cursor, Result as IoResult, Write};
 use std::mem::swap;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::SystemTime;
 
+use chrono::{DateTime, SecondsFormat, Utc};
 use log::LevelFilter;
 
 #[derive(Debug, Default, Clone)]
@@ -56,8 +58,9 @@ pub(super) fn init() {
             fern::Dispatch::new()
                 .format(move |out, message, record| {
                     out.finish(format_args!(
-                        "[{}][{:<7}] {}",
-                        record.target(),
+                        "{} [{:<7}] {}",
+                        DateTime::<Utc>::from(SystemTime::now())
+                            .to_rfc3339_opts(SecondsFormat::Nanos, true),
                         record.level(),
                         message
                     ))

--- a/testkit_backend/src/testkit_backend/driver_holder.rs
+++ b/testkit_backend/src/testkit_backend/driver_holder.rs
@@ -655,6 +655,7 @@ impl DriverHolderRunner {
                     bookmark_manager,
                     tx_meta,
                     timeout,
+                    auth,
                 }) => {
                     let mut builder = self.driver.execute_query(query);
                     if let Some(params) = params {
@@ -683,6 +684,9 @@ impl DriverHolderRunner {
                     }
                     if let Some(timeout) = timeout {
                         builder = builder.with_transaction_timeout(timeout);
+                    }
+                    if let Some(auth) = auth {
+                        builder = builder.with_session_auth(auth);
                     }
                     let result = builder
                         .run_with_retry(ExponentialBackoff::default())
@@ -1051,6 +1055,7 @@ pub(super) struct ExecuteQuery {
     pub(crate) bookmark_manager: ExecuteQueryBookmarkManager,
     pub(super) tx_meta: Option<HashMap<String, ValueSend>>,
     pub(super) timeout: Option<TransactionTimeout>,
+    pub(super) auth: Option<Arc<AuthToken>>,
 }
 
 impl From<ExecuteQuery> for Command {

--- a/testkit_backend/src/testkit_backend/requests.rs
+++ b/testkit_backend/src/testkit_backend/requests.rs
@@ -77,6 +77,8 @@ pub(super) enum Request {
         connection_acquisition_timeout_ms: Option<u64>,
         notifications_min_severity: Option<String>,
         notifications_disabled_categories: Option<Vec<String>>,
+        #[serde(rename = "telemetryDisabled")]
+        telemetry_disabled: Option<bool>,
         encrypted: Option<bool>,
         trusted_certificates: Option<Vec<String>>,
     },
@@ -756,6 +758,7 @@ impl Request {
             connection_acquisition_timeout_ms,
             notifications_min_severity,
             notifications_disabled_categories,
+            telemetry_disabled,
             encrypted,
             trusted_certificates,
         } = self
@@ -828,6 +831,9 @@ impl Request {
             notifications_disabled_categories,
         )? {
             driver_config = driver_config.with_notification_filter(filter);
+        }
+        if let Some(telemetry_disabled) = telemetry_disabled {
+            driver_config = driver_config.with_telemetry(!telemetry_disabled);
         }
         if let Some(encrypted) = encrypted {
             connection_config = match encrypted {

--- a/testkit_backend/src/testkit_backend/requests.rs
+++ b/testkit_backend/src/testkit_backend/requests.rs
@@ -599,6 +599,8 @@ pub(super) struct ExecuteQueryConfig {
     bookmark_manager_id: Option<ExecuteQueryBmmId>,
     tx_meta: Option<HashMap<String, CypherValue>>,
     timeout: Option<i64>,
+    #[serde(rename = "authorizationToken")]
+    auth: MaybeTestKitAuth,
 }
 
 #[derive(Deserialize, Debug)]
@@ -1466,6 +1468,7 @@ impl Request {
             bookmark_manager_id,
             tx_meta,
             timeout,
+            auth,
         } = config;
         let data = backend.data.borrow_mut();
         let driver_holder = get_driver(&data, &driver_id)?;
@@ -1483,6 +1486,7 @@ impl Request {
             .map(cypher_value_map_to_value_send_map)
             .transpose()?;
         let timeout = read_transaction_timeout(timeout)?;
+        let auth = auth.0.map(|auth| Arc::new(auth.into()));
         let result = driver_holder
             .execute_query(ExecuteQuery {
                 query,
@@ -1493,6 +1497,7 @@ impl Request {
                 bookmark_manager,
                 tx_meta,
                 timeout,
+                auth,
             })
             .result?;
         let response: Response = result.try_into()?;

--- a/testkit_backend/src/testkit_backend/responses.rs
+++ b/testkit_backend/src/testkit_backend/responses.rs
@@ -35,8 +35,9 @@ use super::requests::TestKitAuth;
 use super::session_holder::SummaryWithQuery;
 use super::BackendId;
 
+// [bolt-version-bump] search tag when changing bolt version support
 // https://github.com/rust-lang/rust/issues/85077
-const FEATURE_LIST: [&str; 43] = [
+const FEATURE_LIST: [&str; 44] = [
     // === FUNCTIONAL FEATURES ===
     "Feature:API:BookmarkManager",
     "Feature:API:ConnectionAcquisitionTimeout",
@@ -74,7 +75,7 @@ const FEATURE_LIST: [&str; 43] = [
     "Feature:Bolt:5.1",
     "Feature:Bolt:5.2",
     "Feature:Bolt:5.3",
-    // "Feature:Bolt:5.4",
+    "Feature:Bolt:5.4",
     "Feature:Bolt:Patch:UTC",
     "Feature:Impersonation",
     // "Feature:TLS:1.1",  // rustls says no! For a good reason.


### PR DESCRIPTION
Starting with Bolt 5.4, the driver will, by default, send anonymous API usage statistics to the server if requested.

An opt-out is available through `DriverConfig::with_telemetry`:

```rust
let driver = Driver::new(
    connection_config,
    DriverConfig::new().with_telemetry(false),
);
```

If the server requests is, the driver will send anonymous API usage. Currently, everytime one of the following APIs is used to execute a query (for the first time), the server is informed of this (without any further information like arguments, client identifiers, etc.):

 * `ExecuteQueryBuilder::run()` / `ExecuteQueryBuilder::run_with_retry()`
 * `TransactionBuilder::run()`
 * `TransactionBuilder::run_with_retry()`
 * `AutoCommitBuilder::run()`