### PR TITLE
Fix Path type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         pass_filenames: false
       - id: unit
         name: unit tests
-        entry: cargo test --workspace --tests --benches --features _internal_public_api
+        entry: cargo +stable test --workspace --tests --benches --features _internal_public_api
         language: system
         types: [rust]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## NEXT
 ***
+**⭐ New Features**
+ - Rework `neo4j::value::graph::Path`
+   - `Path`s now properly validate data received from the server (as documented)
+   - ⚠️ The return type of `Path::traverse()` was changed to reflect that paths with only one node and no relationships exist.
+   - The invariants of `Path` were changed for the above reason, too.
+   - New methods `Path::new()`, `Path::new_unchecked()`, and `Path::verify_invariants()`.
 
 
 ## 0.1.0

--- a/doc_test_utils/src/lib.rs
+++ b/doc_test_utils/src/lib.rs
@@ -84,13 +84,13 @@ pub fn get_session(driver: &Driver) -> Session {
     )
 }
 
-pub fn with_transaction<R>(example: impl FnMut(Transaction) -> Neo4jResult<R>) {
+pub fn with_transaction<R>(example: impl FnMut(Transaction) -> Neo4jResult<R>) -> R {
     let driver = get_driver();
     let mut session = get_session(&driver);
     session
         .transaction()
         .run_with_retry(ExponentialBackoff::default(), example)
-        .unwrap();
+        .unwrap()
 }
 
 pub fn db_exclusive(work: impl FnOnce() + UnwindSafe) {

--- a/neo4j/src/driver/io/bolt/bolt4x4/translator.rs
+++ b/neo4j/src/driver/io/bolt/bolt4x4/translator.rs
@@ -192,11 +192,10 @@ impl BoltStructTranslator for Bolt4x4StructTranslator {
                 for index in raw_indices {
                     indices.push(as_int!(index, "path index").into_isize());
                 }
-                ValueReceive::Path(Path {
-                    nodes,
-                    relationships,
-                    indices,
-                })
+                match Path::new(nodes, relationships, indices) {
+                    Ok(path) => ValueReceive::Path(path),
+                    Err(e) => invalid_struct(format!("Path invariant violated: {e}")),
+                }
             }
             TAG_DATE_TIME | TAG_DATE_TIME_ZONE_ID if !self.utc_patch => {
                 ValueReceive::BrokenValue(BrokenValue {

--- a/neo4j/src/driver/io/bolt/bolt5x0/translator.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x0/translator.rs
@@ -358,11 +358,10 @@ impl BoltStructTranslator for Bolt5x0StructTranslator {
                 for index in raw_indices {
                     indices.push(as_int!(index, "path index").into_isize());
                 }
-                ValueReceive::Path(Path {
-                    nodes,
-                    relationships,
-                    indices,
-                })
+                match Path::new(nodes, relationships, indices) {
+                    Ok(path) => ValueReceive::Path(path),
+                    Err(e) => invalid_struct(format!("Path invariant violated: {e}")),
+                }
             }
             TAG_DATE => {
                 if size != 1 {

--- a/neo4j/src/driver/io/bolt/bolt_common.rs
+++ b/neo4j/src/driver/io/bolt/bolt_common.rs
@@ -45,7 +45,7 @@ macro_rules! value_as {
                     concat!(
                         "expected ",
                         $name,
-                        " to be an ",
+                        " to be ",
                         $type_name,
                         ", found {0:?}"
                     ),

--- a/neo4j/src/test_data/public-api.txt
+++ b/neo4j/src/test_data/public-api.txt
@@ -1002,6 +1002,57 @@ impl core::panic::unwind_safe::RefUnwindSafe for neo4j::transaction::Transaction
 impl core::panic::unwind_safe::UnwindSafe for neo4j::transaction::TransactionTimeout
 pub mod neo4j::value
 pub mod neo4j::value::graph
+#[non_exhaustive] pub enum neo4j::value::graph::PathInvariantError
+#[non_exhaustive] pub neo4j::value::graph::PathInvariantError::EmptyNodes
+#[non_exhaustive] pub neo4j::value::graph::PathInvariantError::EvenIndexOutOfRange
+pub neo4j::value::graph::PathInvariantError::EvenIndexOutOfRange::index: usize
+pub neo4j::value::graph::PathInvariantError::EvenIndexOutOfRange::relationships_len: usize
+pub neo4j::value::graph::PathInvariantError::EvenIndexOutOfRange::value: isize
+#[non_exhaustive] pub neo4j::value::graph::PathInvariantError::OddIndexOutOfRange
+pub neo4j::value::graph::PathInvariantError::OddIndexOutOfRange::index: usize
+pub neo4j::value::graph::PathInvariantError::OddIndexOutOfRange::nodes_len: usize
+pub neo4j::value::graph::PathInvariantError::OddIndexOutOfRange::value: isize
+#[non_exhaustive] pub neo4j::value::graph::PathInvariantError::TooManyNodes
+#[non_exhaustive] pub neo4j::value::graph::PathInvariantError::TooManyRelationships
+#[non_exhaustive] pub neo4j::value::graph::PathInvariantError::UnevenIndicesCount
+impl core::clone::Clone for neo4j::value::graph::PathInvariantError
+pub fn neo4j::value::graph::PathInvariantError::clone(&self) -> neo4j::value::graph::PathInvariantError
+impl core::cmp::Eq for neo4j::value::graph::PathInvariantError
+impl core::cmp::PartialEq for neo4j::value::graph::PathInvariantError
+pub fn neo4j::value::graph::PathInvariantError::eq(&self, other: &neo4j::value::graph::PathInvariantError) -> bool
+impl core::error::Error for neo4j::value::graph::PathInvariantError
+impl core::fmt::Debug for neo4j::value::graph::PathInvariantError
+pub fn neo4j::value::graph::PathInvariantError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for neo4j::value::graph::PathInvariantError
+pub fn neo4j::value::graph::PathInvariantError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for neo4j::value::graph::PathInvariantError
+impl core::marker::Freeze for neo4j::value::graph::PathInvariantError
+impl core::marker::Send for neo4j::value::graph::PathInvariantError
+impl core::marker::Sync for neo4j::value::graph::PathInvariantError
+impl core::marker::Unpin for neo4j::value::graph::PathInvariantError
+impl core::panic::unwind_safe::RefUnwindSafe for neo4j::value::graph::PathInvariantError
+impl core::panic::unwind_safe::UnwindSafe for neo4j::value::graph::PathInvariantError
+pub enum neo4j::value::graph::RelationshipDirection
+pub neo4j::value::graph::RelationshipDirection::From
+pub neo4j::value::graph::RelationshipDirection::To
+impl core::clone::Clone for neo4j::value::graph::RelationshipDirection
+pub fn neo4j::value::graph::RelationshipDirection::clone(&self) -> neo4j::value::graph::RelationshipDirection
+impl core::cmp::Eq for neo4j::value::graph::RelationshipDirection
+impl core::cmp::PartialEq for neo4j::value::graph::RelationshipDirection
+pub fn neo4j::value::graph::RelationshipDirection::eq(&self, other: &neo4j::value::graph::RelationshipDirection) -> bool
+impl core::fmt::Debug for neo4j::value::graph::RelationshipDirection
+pub fn neo4j::value::graph::RelationshipDirection::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for neo4j::value::graph::RelationshipDirection
+pub fn neo4j::value::graph::RelationshipDirection::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for neo4j::value::graph::RelationshipDirection
+pub fn neo4j::value::graph::RelationshipDirection::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for neo4j::value::graph::RelationshipDirection
+impl core::marker::Freeze for neo4j::value::graph::RelationshipDirection
+impl core::marker::Send for neo4j::value::graph::RelationshipDirection
+impl core::marker::Sync for neo4j::value::graph::RelationshipDirection
+impl core::marker::Unpin for neo4j::value::graph::RelationshipDirection
+impl core::panic::unwind_safe::RefUnwindSafe for neo4j::value::graph::RelationshipDirection
+impl core::panic::unwind_safe::UnwindSafe for neo4j::value::graph::RelationshipDirection
 #[non_exhaustive] pub struct neo4j::value::graph::Node
 pub neo4j::value::graph::Node::element_id: alloc::string::String
 pub neo4j::value::graph::Node::id: i64
@@ -1030,7 +1081,8 @@ pub neo4j::value::graph::Path::indices: alloc::vec::Vec<isize>
 pub neo4j::value::graph::Path::nodes: alloc::vec::Vec<neo4j::value::graph::Node>
 pub neo4j::value::graph::Path::relationships: alloc::vec::Vec<neo4j::value::graph::UnboundRelationship>
 impl neo4j::value::graph::Path
-pub fn neo4j::value::graph::Path::traverse(&self) -> alloc::vec::Vec<(&neo4j::value::graph::Node, &neo4j::value::graph::UnboundRelationship, &neo4j::value::graph::Node)>
+pub fn neo4j::value::graph::Path::traverse(&self) -> (&neo4j::value::graph::Node, alloc::vec::Vec<(neo4j::value::graph::RelationshipDirection, &neo4j::value::graph::UnboundRelationship, &neo4j::value::graph::Node)>)
+pub fn neo4j::value::graph::Path::verify_invariants(&self) -> core::result::Result<(), neo4j::value::graph::PathInvariantError>
 impl core::clone::Clone for neo4j::value::graph::Path
 pub fn neo4j::value::graph::Path::clone(&self) -> neo4j::value::graph::Path
 impl core::cmp::PartialEq for neo4j::value::graph::Path

--- a/neo4j/src/value/graph.rs
+++ b/neo4j/src/value/graph.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
 use super::ValueReceive;
 
@@ -62,16 +63,7 @@ impl Display for Relationship {
 ///
 /// It's not recommended to access the fields directly, but rather use [`Path::traverse()`] because
 /// the fields' semantics are rather complicated and mutating them in a way that violates the
-/// invariants (below) will cause many methods to panic.
-///
-/// # Invariants
-///  * `indices`
-///    * is not empty
-///    * has an even number of elements
-///    * 1st, 3rd, ... entry is in the range
-///      `-self.nodes.len()..0` or `1..=self.relationships.len()`
-///    * 2nd, 4th, ... entry is in the range `0..self.nodes.len()`
-///  * (this implies `nodes` and `relationships` are not empty)
+/// [invariants](`Path::verify_invariants()`) will cause many methods to panic.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Path {
     pub nodes: Vec<Node>,
@@ -82,81 +74,231 @@ pub struct Path {
 }
 
 impl Path {
-    /// Returns the nodes and relationships in the order they appear in the path.
+    /// Initializes a new `Path` verifying its [invariants](`Path::verify_invariants()`).
+    pub(crate) fn new(
+        nodes: Vec<Node>,
+        relationships: Vec<UnboundRelationship>,
+        indices: Vec<isize>,
+    ) -> Result<Self, PathInvariantError> {
+        let path = Self::new_unchecked(nodes, relationships, indices);
+        path.verify_invariants().map(|_| path)
+    }
+
+    /// Initializes a new `Path` without verifying its [invariants](`Path::verify_invariants()`)
+    pub(crate) fn new_unchecked(
+        nodes: Vec<Node>,
+        relationships: Vec<UnboundRelationship>,
+        indices: Vec<isize>,
+    ) -> Self {
+        Self {
+            nodes,
+            relationships,
+            indices,
+        }
+    }
+
+    /// Verifies the invariants of the path.
+    ///
+    /// # Invariants
+    ///  * `indices`
+    ///    * has an even number of elements
+    ///    * odd entries (1st, 3rd, ...) are is in the range
+    ///      `-self.relationships.len()..=-1` or `1..=self.relationships.len()`
+    ///    * even entries (2nd, 4th, ...) are in the range `0..self.nodes.len()`
+    ///  * `nodes` is not empty
+    ///
+    /// # Example
+    /// ```
+    /// # fn get_path() -> Path {
+    /// #     doc_test_utils::with_transaction(|tx| {
+    /// #         Ok(tx
+    /// #             .query("CREATE p=(a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) RETURN p")
+    /// #             .run()?
+    /// #             .single()
+    /// #             .unwrap()?
+    /// #             .take_value("p")
+    /// #             .unwrap()
+    /// #             .try_into_path()
+    /// #             .unwrap())
+    /// #     })
+    /// # }
+    /// use neo4j::value::graph::Path;
+    ///
+    /// let mut path: Path = get_path();
+    /// assert!(path.verify_invariants().is_ok());
+    ///
+    /// path.indices[0] = 0; // modification that violates the invariants
+    /// assert!(path.verify_invariants().is_err());
+    /// ```
+    pub fn verify_invariants(&self) -> Result<(), PathInvariantError> {
+        if self.nodes.is_empty() {
+            return Err(PathInvariantError::EmptyNodes {});
+        }
+        if self.indices.len() % 2 != 0 {
+            return Err(PathInvariantError::UnevenIndicesCount {});
+        }
+        let rel_len = self.relationships.len();
+        if rel_len > (isize::MAX - 1) as usize {
+            return Err(PathInvariantError::TooManyRelationships {});
+        }
+        let rel_len_i: isize = rel_len.try_into().expect("checked range above");
+        let node_len = self.nodes.len();
+        if node_len > isize::MAX as usize {
+            return Err(PathInvariantError::TooManyNodes {});
+        }
+        let node_len_i: isize = node_len.try_into().expect("checked range above");
+        for (i, idx) in self.indices.iter().enumerate() {
+            if i % 2 == 0 {
+                // relationship index
+                if !(-rel_len_i..=-1).contains(idx) && !(1..=rel_len_i).contains(idx) {
+                    return Err(PathInvariantError::EvenIndexOutOfRange {
+                        index: i,
+                        value: *idx,
+                        relationships_len: rel_len,
+                    });
+                }
+            } else {
+                // node index
+                if !(0..node_len_i).contains(idx) {
+                    return Err(PathInvariantError::OddIndexOutOfRange {
+                        index: i,
+                        value: *idx,
+                        nodes_len: node_len,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the nodes and relationships in the order they appear on the path.
+    ///
+    /// The first element of the tuple is the start node of the path.
+    /// The second element is a list of tuples, where each tuple contains a relationship and the
+    /// next node on the path.
     ///
     /// # Panics
     /// Panics if `self.nodes`, `self.relationships` or `self.indices` has been tempered with, in
-    /// a way that violates the [invariants of a `Path`](`Path`#invariants).
+    /// a way that violates the [invariants of a `Path`](`Path::verify_invariants()`).
     /// Such an invalid path cannot be obtained from the database, as the database's return values
     /// are checked for validity before being converted to `Path`.
-    pub fn traverse(&self) -> Vec<(&Node, &UnboundRelationship, &Node)> {
+    pub fn traverse(
+        &self,
+    ) -> (
+        &Node,
+        Vec<(RelationshipDirection, &UnboundRelationship, &Node)>,
+    ) {
         let mut result = Vec::with_capacity(self.indices.len() / 2);
+        if self.indices.is_empty() {
+            return (&self.nodes[0], result);
+        }
         let mut index_iter = self.indices.iter();
-        let mut prev_node_idx = 0;
-        let mut relationship_idx = *index_iter.next().expect("indices cannot be empty");
-        let mut next_node_idx = index_iter
-            .next()
-            .expect("indices must contain at least 2 elements")
-            .to_owned()
-            .try_into()
-            .expect("2nd, 4th, ... entry in indices must be in the >= 0");
-        loop {
-            let mut start_node = &self.nodes[prev_node_idx];
-            let mut end_node = &self.nodes[next_node_idx];
-            if relationship_idx < 0 {
-                (start_node, end_node) = (end_node, start_node);
-                relationship_idx = -relationship_idx;
-            }
-            relationship_idx -= 1;
-            let relationship = {
-                let relationship_idx: usize = relationship_idx
-                    .try_into()
-                    .expect("1st, 3rd, ... entry in indices cannot be 0");
-                &self.relationships[relationship_idx]
-            };
-            result.push((start_node, relationship, end_node));
-
-            let Some(next_relationship_idx) = index_iter.next() else {
-                break;
-            };
-            relationship_idx = *next_relationship_idx;
-            prev_node_idx = next_node_idx;
-            next_node_idx = index_iter
+        while let Some(mut relationship_idx) = index_iter.next().copied() {
+            let next_node_idx: usize = index_iter
                 .next()
                 .expect("indices must contain an even number of elements")
                 .to_owned()
                 .try_into()
                 .expect("2nd, 4th, ... entry in indices must be >= 0");
+            let next_node = &self.nodes[next_node_idx];
+            let direction = if relationship_idx < 0 {
+                relationship_idx = -relationship_idx;
+                RelationshipDirection::From
+            } else {
+                RelationshipDirection::To
+            };
+            relationship_idx -= 1;
+            let relationship = {
+                let relationship_idx: usize = relationship_idx
+                    .try_into()
+                    .expect("odd indices entries cannot be 0");
+                &self.relationships[relationship_idx]
+            };
+            result.push((direction, relationship, next_node));
         }
-        result
+        (&self.nodes[0], result)
     }
 }
 
 /// # Panics
-/// Panics if [`Path`'s invariants](`Path`#invariants) are violated.
+/// Panics if [`Path`'s invariants](`Path::verify_invariants()`) are violated.
 impl Display for Path {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut last_node = &self.nodes[0];
-        write!(f, "({})", last_node.element_id)?;
-        for (start_node, relationship, end_node) in self.traverse() {
-            if last_node.element_id == start_node.element_id {
-                write!(
-                    f,
-                    "-[{}]->({})",
-                    relationship.element_id, end_node.element_id
-                )?;
-                last_node = end_node;
-            } else {
-                assert_eq!(last_node.element_id, end_node.element_id);
-                write!(
-                    f,
-                    "<-[{}]-({})",
-                    relationship.element_id, start_node.element_id
-                )?;
-                last_node = start_node;
+        let (start_node, hops) = self.traverse();
+        write!(f, "({})", start_node.element_id)?;
+        for (direction, relationship, next_node) in hops {
+            match direction {
+                RelationshipDirection::To => {
+                    write!(
+                        f,
+                        "-[{}]->({})",
+                        relationship.element_id, next_node.element_id
+                    )?;
+                }
+                RelationshipDirection::From => {
+                    write!(
+                        f,
+                        "<-[{}]-({})",
+                        relationship.element_id, next_node.element_id
+                    )?;
+                }
             }
         }
         Ok(())
+    }
+}
+
+/// Represents an error that occurred because a [Path's invariants](`Path::verify_invariants()`)
+/// were violated.
+#[derive(Debug, Clone, Error, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PathInvariantError {
+    /// [`Path::nodes`] must not be empty.
+    #[error("nodes must not be empty")]
+    #[non_exhaustive]
+    EmptyNodes {},
+    /// [`Path::indices`] must have an even number of elements.
+    #[error("indices must have an even number of elements")]
+    #[non_exhaustive]
+    UnevenIndicesCount {},
+    /// [`Path::relationships`] must be <= `[`isize::MAX`] - 1`.
+    #[error("number of relationships must be <= {max} (isize::MAX - 1)", max = isize::MAX - 1)]
+    #[non_exhaustive]
+    TooManyRelationships {},
+    /// [`Path::nodes`] must be <= [`isize::MAX`].
+    #[error("number of nodes must be <= {max} (isize::MAX)", max = isize::MAX)]
+    #[non_exhaustive]
+    TooManyNodes {},
+    /// [`Path::nodes`] must be <= [`isize::MAX`].
+    #[error("indices[{index}]={value} must be in the range -{relationships_len}..=-1 or 1..={relationships_len}")]
+    #[non_exhaustive]
+    EvenIndexOutOfRange {
+        index: usize,
+        value: isize,
+        relationships_len: usize,
+    },
+    /// [`Path::nodes`] must be <= [`isize::MAX`].
+    #[error("indices[{index}]={value} must be in the range 0..{nodes_len}")]
+    #[non_exhaustive]
+    OddIndexOutOfRange {
+        index: usize,
+        value: isize,
+        nodes_len: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RelationshipDirection {
+    To,
+    From,
+}
+
+impl Display for RelationshipDirection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RelationshipDirection::To => write!(f, "->"),
+            RelationshipDirection::From => write!(f, "<-"),
+        }
     }
 }
 
@@ -170,4 +312,214 @@ pub struct UnboundRelationship {
     pub type_: String,
     pub properties: HashMap<String, ValueReceive>,
     pub element_id: String,
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn get_nodes(n: usize, label: impl ToString, element_id: bool) -> Vec<Node> {
+        let mut nodes = Vec::with_capacity(n);
+        for i in 0..n {
+            nodes.push(Node {
+                id: i as i64,
+                labels: vec![label.to_string()],
+                properties: HashMap::new(),
+                element_id: if element_id {
+                    format!("n{}", i + 1)
+                } else {
+                    "".to_string()
+                },
+            });
+        }
+        nodes
+    }
+
+    fn get_rels(n: usize, type_: impl ToString, element_id: bool) -> Vec<UnboundRelationship> {
+        let mut rels = Vec::with_capacity(n);
+        for i in 0..n {
+            rels.push(UnboundRelationship {
+                id: n as i64,
+                type_: type_.to_string(),
+                properties: HashMap::new(),
+                element_id: if element_id {
+                    format!("r{}", i + 1)
+                } else {
+                    "".to_string()
+                },
+            })
+        }
+        rels
+    }
+
+    fn get_path() -> Path {
+        // (n1)<-[r1]-(n2)-[r2]->(n1)-[r1]->(n3)
+        let nodes = get_nodes(3, "Person", true);
+        let relationships = get_rels(2, "KNOWS", true);
+        let indices = vec![
+            -1, // r1 (reverse)
+            1,  // n2
+            2,  // r2
+            0,  // n1
+            1,  // r1
+            2,  // n3
+        ];
+        Path::new(nodes, relationships, indices).unwrap()
+    }
+
+    fn get_invalid_path_empty_nodes() -> Path {
+        Path::new_unchecked(vec![], vec![], vec![])
+    }
+
+    fn get_invalid_path_uneven_indices_count() -> Path {
+        let mut path = get_path();
+        path.indices.pop();
+        path
+    }
+
+    #[allow(dead_code)]
+    fn get_invalid_path_too_many_relationships() -> Path {
+        let mut path = get_path();
+        path.relationships = get_rels((isize::MAX - 1) as usize, "", false);
+        path
+    }
+
+    #[allow(dead_code)]
+    fn get_invalid_path_too_many_nodes() -> Path {
+        let mut path = get_path();
+        path.nodes = get_nodes(isize::MAX as usize, "", false);
+        path
+    }
+
+    fn get_invalid_path_even_index_out_of_range_1() -> Path {
+        let mut path = get_path();
+        path.indices[0] = 0;
+        path
+    }
+
+    fn get_invalid_path_even_index_out_of_range_2() -> Path {
+        let mut path = get_path();
+        let rel_len_i: isize = path.relationships.len().try_into().unwrap();
+        path.indices[2] = rel_len_i + 1;
+        path
+    }
+
+    fn get_invalid_path_even_index_out_of_range_3() -> Path {
+        let mut path = get_path();
+        let rel_len_i: isize = path.relationships.len().try_into().unwrap();
+        path.indices[2] = rel_len_i * -1 - 1;
+        path
+    }
+
+    fn get_invalid_path_odd_index_out_of_range_1() -> Path {
+        let mut path = get_path();
+        path.indices[1] = -1;
+        path
+    }
+
+    fn get_invalid_path_odd_index_out_of_range_2() -> Path {
+        let mut path = get_path();
+        path.indices[3] = path.nodes.len().try_into().unwrap();
+        path
+    }
+
+    #[test]
+    fn test_path_display() {
+        let path = get_path();
+        assert_eq!(path.to_string(), "(n1)<-[r1]-(n2)-[r2]->(n1)-[r1]->(n3)");
+    }
+
+    #[test]
+    fn test_path_traverse() {
+        let path = get_path();
+        let expected_node_ids = vec!["n1", "n2", "n1", "n3"];
+        let expected_directions = vec![
+            RelationshipDirection::From,
+            RelationshipDirection::To,
+            RelationshipDirection::To,
+        ];
+        let expected_relationship_ids = vec!["r1", "r2", "r1"];
+
+        let (start_node, hops) = path.traverse();
+        assert_eq!(start_node.element_id, expected_node_ids[0]);
+        for (i, (direction, relationship, next_node)) in hops.iter().enumerate() {
+            assert_eq!(direction, &expected_directions[i]);
+            assert_eq!(relationship.element_id, expected_relationship_ids[i]);
+            assert_eq!(next_node.element_id, expected_node_ids[i + 1]);
+        }
+    }
+
+    #[rstest]
+    #[case(get_path(), Ok(()))]
+    #[case(
+        get_invalid_path_empty_nodes(),
+        Err(PathInvariantError::EmptyNodes {})
+    )]
+    #[case(
+        get_invalid_path_uneven_indices_count(),
+        Err(PathInvariantError::UnevenIndicesCount {})
+    )]
+    // #[case(
+    //     get_invalid_path_too_many_relationships(),
+    //     Err(PathInvariantError::TooManyRelationships {})
+    // )]
+    // #[case(
+    //     get_invalid_path_too_many_nodes(),
+    //     Err(PathInvariantError::TooManyNodes {})
+    // )]
+    #[case(
+        get_invalid_path_even_index_out_of_range_1(),
+        Err(PathInvariantError::EvenIndexOutOfRange {
+            index: 0,
+            value: 0,
+            relationships_len: 2
+        })
+    )]
+    #[case(
+        get_invalid_path_even_index_out_of_range_2(),
+        Err(PathInvariantError::EvenIndexOutOfRange {
+            index: 2,
+            value: 3,
+            relationships_len: 2
+        })
+    )]
+    #[case(
+        get_invalid_path_even_index_out_of_range_3(),
+        Err(PathInvariantError::EvenIndexOutOfRange {
+            index: 2,
+            value: -3,
+            relationships_len: 2
+        })
+    )]
+    #[case(
+        get_invalid_path_odd_index_out_of_range_1(),
+        Err(PathInvariantError::OddIndexOutOfRange {
+            index: 1,
+            value: -1,
+            nodes_len: 3
+        })
+    )]
+    #[case(
+        get_invalid_path_odd_index_out_of_range_2(),
+        Err(PathInvariantError::OddIndexOutOfRange {
+            index: 3,
+            value: 3,
+            nodes_len: 3
+        })
+    )]
+    fn test_path_invariants(#[case] path: Path, #[case] expected: Result<(), PathInvariantError>) {
+        assert_eq!(path.verify_invariants(), expected);
+
+        let Path {
+            nodes,
+            relationships,
+            indices,
+        } = path.clone();
+        assert_eq!(
+            Path::new(nodes, relationships, indices),
+            expected.map(|_| path)
+        );
+    }
 }


### PR DESCRIPTION
Fix `neo4j::value::graph::Path` not properly handling paths only containing a single node.