### PR TITLE
Feat: Bolt 5.8 - home db cache & optimistic routing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,25 @@ repos:
     hooks:
       - id: check
         name: cargo check
-        entry: cargo check --
+        entry: cargo +stable check --all --tests --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: check-msrv-all-features
+        name: cargo check (all features)
+        entry: cargo +stable check --all --tests --all-features --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: check-msrv
+        name: cargo check MSRV
+        entry: cargo +1.70 check --all --tests --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: check-msrv-all-features
+        name: cargo check MSRV (all features)
+        entry: cargo +1.70 check --all --tests --all-features --
         language: system
         types: [rust]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
      User-code should not need to create arbitrary `ServerError`s.
      In return, `ServerError` now implements `Clone`.
  - Add support for bolt handshake manifest v1.
+ - Add support for Bolt 5.8 (home database resolution cache)
+   - Includes an optimization where the driver uses a home/default database cache to perform optimistic routing under certain circumstances, saving a full round trip. See the [PR description](https://github.com/robsdedude/neo4j-rust-driver/pull/28) for more details.
 
 **🔧 Fixes**
  - Rework `neo4j::value::graph::Path`

--- a/neo4j/src/driver/config.rs
+++ b/neo4j/src/driver/config.rs
@@ -795,7 +795,7 @@ impl ConnectionConfig {
                 }
             }
             Some(query) => {
-                if query == "" {
+                if query.is_empty() {
                     Some(HashMap::new())
                 } else {
                     if !routing {

--- a/neo4j/src/driver/home_db_cache.rs
+++ b/neo4j/src/driver/home_db_cache.rs
@@ -46,7 +46,11 @@ impl Default for HomeDbCache {
 impl HomeDbCache {
     pub(super) fn new(max_size: usize) -> Self {
         let max_size_f64 = max_size as f64;
-        let prune_size = usize::min(max_size, (max_size_f64 * 0.01).log(max_size_f64) as usize);
+        let mut prune_size = (0.01 * max_size_f64 * max_size_f64.ln()) as usize;
+        prune_size = usize::min(prune_size, max_size);
+        if prune_size == 0 && max_size > 0 {
+            prune_size = 1; // ensure at least one entry is pruned
+        }
         HomeDbCache {
             cache: Mutex::new(HashMap::with_capacity(max_size)),
             config: HomeDbCacheConfig {
@@ -221,11 +225,8 @@ impl SessionAuthKey {
 }
 
 impl HomeDbCacheKey {
-    pub(super) fn new(
-        imp_user: Option<&Arc<String>>,
-        session_auth: Option<&Arc<AuthToken>>,
-    ) -> Self {
-        if let Some(user) = imp_user {
+    pub(super) fn new(user: Option<&Arc<String>>, session_auth: Option<&Arc<AuthToken>>) -> Self {
+        if let Some(user) = user {
             HomeDbCacheKey::FixedUser(Arc::clone(user))
         } else if let Some(auth) = session_auth {
             if let Some(ValueSend::String(scheme)) = auth.data.get("scheme") {
@@ -246,4 +247,223 @@ impl HomeDbCacheKey {
 struct HomeDbCacheEntry {
     database: Arc<String>,
     last_used: Instant,
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::*;
+
+    use crate::value::time;
+    use crate::value_map;
+
+    use super::*;
+
+    #[rstest]
+    #[case(HashMap::new(), HashMap::new())]
+    #[case(
+        value_map!({
+            "list": [1, 1.5, ValueSend::Null, "string", true],
+            "principal": "user",
+            "map": value_map!({
+                "nested": value_map!({
+                    "key": "value",
+                    "when": time::LocalDateTime::new(
+                        time::Date::from_ymd_opt(2021, 1, 1).unwrap(),
+                        time::LocalTime::from_hms_opt(12, 0, 0).unwrap(),
+                    ),
+                }),
+                "point": spatial::Cartesian2D::new(1.0, 2.0),
+                "key": "value",
+            }),
+            "nan": ValueSend::Float(f64::NAN),
+            "foo": "bar",
+        }),
+        value_map!({
+            "foo": "bar",
+            "principal": "user",
+            "nan": ValueSend::Float(f64::NAN),
+            "list": [1, 1.5, ValueSend::Null, "string", true],
+            "map": value_map!({
+                "key": "value",
+                "nested": value_map!({
+                    "key": "value",
+                    "when": time::LocalDateTime::new(
+                        time::Date::from_ymd_opt(2021, 1, 1).unwrap(),
+                        time::LocalTime::from_hms_opt(12, 0, 0).unwrap(),
+                    ),
+                }),
+                "point": spatial::Cartesian2D::new(1.0, 2.0),
+            }),
+        })
+    )]
+    fn test_cache_key_equality(
+        #[case] a: HashMap<String, ValueSend>,
+        #[case] b: HashMap<String, ValueSend>,
+    ) {
+        let auth1 = Arc::new(AuthToken { data: a });
+        let auth2 = Arc::new(AuthToken { data: b });
+        let key1 = HomeDbCacheKey::SessionAuth(SessionAuthKey(Arc::clone(&auth1)));
+        let key2 = HomeDbCacheKey::SessionAuth(SessionAuthKey(Arc::clone(&auth2)));
+        #[allow(clippy::eq_op)] // we're explicitly testing the equality implementation here
+        {
+            assert_eq!(key1, key1);
+            assert_eq!(key2, key2);
+        }
+        assert_eq!(key1, key2);
+        assert_eq!(key2, key1);
+
+        let mut hasher1 = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher2 = std::collections::hash_map::DefaultHasher::new();
+        key1.hash(&mut hasher1);
+        key2.hash(&mut hasher2);
+        assert_eq!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[rstest]
+    #[case(value_map!({"principal": "user"}), value_map!({"principal": "admin"}))]
+    #[case(value_map!({"int": 1}), value_map!({"int": 2}))]
+    #[case(value_map!({"int": 1}), value_map!({"int": 1.0}))]
+    #[case(value_map!({"zero": 0.0}), value_map!({"zero": -0.0}))]
+    #[case(value_map!({"large": f64::INFINITY}), value_map!({"large": f64::NEG_INFINITY}))]
+    #[case(value_map!({"nan": f64::NAN}), value_map!({"nan": -f64::NAN}))]
+    #[case(value_map!({"int": 1}), value_map!({"int": "1"}))]
+    #[case(value_map!({"list": [1, 2]}), value_map!({"list": [2, 1]}))]
+    fn test_cache_key_inequality(
+        #[case] a: HashMap<String, ValueSend>,
+        #[case] b: HashMap<String, ValueSend>,
+    ) {
+        let auth1 = Arc::new(AuthToken { data: a });
+        let auth2 = Arc::new(AuthToken { data: b });
+        let key1 = HomeDbCacheKey::SessionAuth(SessionAuthKey(Arc::clone(&auth1)));
+        let key2 = HomeDbCacheKey::SessionAuth(SessionAuthKey(Arc::clone(&auth2)));
+        assert_ne!(key1, key2);
+    }
+
+    fn fixed_user_key(user: &str) -> HomeDbCacheKey {
+        HomeDbCacheKey::FixedUser(Arc::new(user.to_string()))
+    }
+
+    fn auth_basic(principal: &str) -> AuthToken {
+        AuthToken {
+            data: value_map!({
+                "scheme": "basic",
+                "principal": principal,
+                "credentials": "password",
+            }),
+        }
+    }
+
+    fn any_auth_key() -> HomeDbCacheKey {
+        HomeDbCacheKey::SessionAuth(SessionAuthKey(Arc::new(AuthToken {
+            data: Default::default(),
+        })))
+    }
+
+    #[rstest]
+    #[case(None, None, HomeDbCacheKey::DriverUser)]
+    #[case(Some("user"), None, fixed_user_key("user"))]
+    #[case(Some("user"), Some(auth_basic("user2")), fixed_user_key("user"))]
+    #[case(
+        None,
+        Some(AuthToken::new_basic_auth("user2", "password")),
+        fixed_user_key("user2")
+    )]
+    #[case(
+        None,
+        Some(AuthToken::new_basic_auth_with_realm("user2", "password", "my-realm")),
+        fixed_user_key("user2")
+    )]
+    #[case(None, Some(AuthToken::new_basic_auth("", "empty")), fixed_user_key(""))]
+    #[case(None, Some(AuthToken::new_none_auth()), any_auth_key())]
+    #[case(None, Some(AuthToken::new_bearer_auth("token123")), any_auth_key())]
+    #[case(None, Some(AuthToken::new_kerberos_auth("token123")), any_auth_key())]
+    #[case(
+        None,
+        Some(AuthToken::new_custom_auth(None, None, None, None, None)),
+        any_auth_key()
+    )]
+    #[case(
+        None,
+        Some(AuthToken::new_custom_auth(
+            Some("principal".into()),
+            Some("credentials".into()),
+            Some("realm".into()),
+            Some("scheme".into()),
+            Some(value_map!({"key": "value"})),
+        )),
+        any_auth_key()
+    )]
+    fn test_cache_key_new(
+        #[case] user: Option<&str>,
+        #[case] session_auth: Option<AuthToken>,
+        #[case] expected: HomeDbCacheKey,
+    ) {
+        let user = user.map(String::from).map(Arc::new);
+        let session_auth = session_auth.map(Arc::new);
+        let expected = match expected {
+            HomeDbCacheKey::SessionAuth(_) => HomeDbCacheKey::SessionAuth(SessionAuthKey(
+                Arc::clone(session_auth.as_ref().unwrap()),
+            )),
+            _ => expected,
+        };
+        assert_eq!(
+            HomeDbCacheKey::new(user.as_ref(), session_auth.as_ref()),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case(0, 0)]
+    #[case(1, 1)]
+    #[case(5, 1)]
+    #[case(50, 1)]
+    #[case(60, 2)]
+    #[case(100, 4)]
+    #[case(200, 10)]
+    #[case(1_000, 69)]
+    #[case(10_000, 921)]
+    #[case(100_000, 11_512)]
+    #[case(1_000_000, 138_155)]
+    fn test_cache_pruning_size(#[case] max_size: usize, #[case] expected: usize) {
+        let cache = HomeDbCache::new(max_size);
+        assert_eq!(cache.config.prune_size, expected);
+    }
+
+    #[test]
+    fn test_pruning() {
+        const SIZE: usize = 200;
+        const PRUNE_SIZE: usize = 10;
+        let cache = HomeDbCache::new(SIZE);
+        // sanity check
+        assert_eq!(cache.config.prune_size, PRUNE_SIZE);
+
+        let users: Vec<_> = (0..=SIZE).map(|i| Arc::new(format!("user{i}"))).collect();
+        let keys: Vec<_> = (0..=SIZE)
+            .map(|i| HomeDbCacheKey::new(Some(&users[i]), None))
+            .collect();
+        let entries: Vec<_> = (0..=SIZE).map(|i| Arc::new(format!("db{i}"))).collect();
+
+        // WHEN: cache is filled to the max
+        for i in 0..SIZE {
+            cache.update(keys[i].clone(), Arc::clone(&entries[i]));
+        }
+        // THEN: no entry has been removed
+        for i in 0..SIZE {
+            assert_eq!(cache.get(&keys[i]), Some(Arc::clone(&entries[i])));
+        }
+
+        // WHEN: The oldest entry is touched
+        cache.get(&keys[0]);
+        // AND: cache is filled with one more entry
+        cache.update(keys[SIZE].clone(), Arc::clone(&entries[SIZE]));
+        // THEN: the oldest PRUNE_SIZE entries (2nd to (PRUNE_SIZE + 1)th) are pruned
+        for key in keys.iter().skip(1).take(PRUNE_SIZE) {
+            assert_eq!(cache.get(key), None);
+        }
+        // AND: the rest of the entries are still in the cache
+        assert_eq!(cache.get(&keys[0]), Some(Arc::clone(&entries[0])));
+        for i in PRUNE_SIZE + 2..=SIZE {
+            assert_eq!(cache.get(&keys[i]), Some(Arc::clone(&entries[i])));
+        }
+    }
 }

--- a/neo4j/src/driver/home_db_cache.rs
+++ b/neo4j/src/driver/home_db_cache.rs
@@ -1,0 +1,249 @@
+// Copyright Rouven Bauer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+use log::debug;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::mem;
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::auth::AuthToken;
+use crate::value::spatial;
+use crate::{value, ValueSend};
+
+#[derive(Debug)]
+pub(super) struct HomeDbCache {
+    cache: Mutex<HashMap<HomeDbCacheKey, HomeDbCacheEntry>>,
+    config: HomeDbCacheConfig,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct HomeDbCacheConfig {
+    max_size: usize,
+    prune_size: usize,
+}
+
+impl Default for HomeDbCache {
+    fn default() -> Self {
+        Self::new(1000)
+    }
+}
+
+impl HomeDbCache {
+    pub(super) fn new(max_size: usize) -> Self {
+        let max_size_f64 = max_size as f64;
+        let prune_size = usize::min(max_size, (max_size_f64 * 0.01).log(max_size_f64) as usize);
+        HomeDbCache {
+            cache: Mutex::new(HashMap::with_capacity(max_size)),
+            config: HomeDbCacheConfig {
+                max_size,
+                prune_size,
+            },
+        }
+    }
+
+    pub(super) fn get(&self, key: &HomeDbCacheKey) -> Option<Arc<String>> {
+        let mut lock = self.cache.lock();
+        let cache: &mut HashMap<HomeDbCacheKey, HomeDbCacheEntry> = &mut lock;
+        let res = cache.get_mut(key).map(|entry| {
+            entry.last_used = Instant::now();
+            Arc::clone(&entry.database)
+        });
+        debug!(
+            "Getting home database cache for key: {} -> {:?}",
+            key.log_str(),
+            res.as_deref(),
+        );
+        res
+    }
+
+    pub(super) fn update(&self, key: HomeDbCacheKey, database: Arc<String>) {
+        let mut lock = self.cache.lock();
+        debug!(
+            "Updating home database cache for key: {} -> {:?}",
+            key.log_str(),
+            database.as_str(),
+        );
+        let cache: &mut HashMap<HomeDbCacheKey, HomeDbCacheEntry> = &mut lock;
+        let previous_val = cache.insert(
+            key,
+            HomeDbCacheEntry {
+                database,
+                last_used: Instant::now(),
+            },
+        );
+        if previous_val.is_none() {
+            // cache grew, prune if necessary
+            Self::prune(cache, self.config);
+        }
+    }
+
+    fn prune(cache: &mut HashMap<HomeDbCacheKey, HomeDbCacheEntry>, config: HomeDbCacheConfig) {
+        if cache.len() <= config.max_size {
+            return;
+        }
+        debug!(
+            "Pruning home database cache to size: {}",
+            config.max_size - config.prune_size
+        );
+        let new_cache = mem::take(cache);
+        *cache = new_cache
+            .into_iter()
+            .sorted_by(|(_, v1), (_, v2)| v2.last_used.cmp(&v1.last_used))
+            .take(config.max_size - config.prune_size)
+            .collect();
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) enum HomeDbCacheKey {
+    DriverUser,
+    FixedUser(Arc<String>),
+    SessionAuth(SessionAuthKey),
+}
+
+impl HomeDbCacheKey {
+    fn log_str(&self) -> String {
+        match self {
+            HomeDbCacheKey::DriverUser | HomeDbCacheKey::FixedUser(_) => format!("{:?}", self),
+            HomeDbCacheKey::SessionAuth(SessionAuthKey(auth)) => {
+                let mut auth: AuthToken = (**auth).clone();
+                auth.data
+                    .get_mut("credentials")
+                    .map(|c| *c = value!("**********"));
+                format!("SessionAuth({:?})", auth.data)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct SessionAuthKey(Arc<AuthToken>);
+
+impl PartialEq for SessionAuthKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+            || self.0.data.len() == other.0.data.len()
+                && self
+                    .0
+                    .data
+                    .iter()
+                    .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
+                    .zip(other.0.data.iter().sorted_by(|(k1, _), (k2, _)| k1.cmp(k2)))
+                    .all(|((k1, v1), (k2, v2))| k1 == k2 && v1.eq_data(v2))
+    }
+}
+
+impl Eq for SessionAuthKey {}
+
+impl Hash for SessionAuthKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0
+            .data
+            .iter()
+            .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
+            .for_each(|(k, v)| {
+                k.hash(state);
+                Self::hash(v, state);
+            });
+    }
+}
+
+impl SessionAuthKey {
+    fn hash(v: &ValueSend, state: &mut impl Hasher) {
+        match v {
+            ValueSend::Null => state.write_usize(0),
+            ValueSend::Boolean(v) => v.hash(state),
+            ValueSend::Integer(v) => v.hash(state),
+            ValueSend::Float(v) => v.to_bits().hash(state),
+            ValueSend::Bytes(v) => v.hash(state),
+            ValueSend::String(v) => v.hash(state),
+            ValueSend::List(v) => v.iter().for_each(|v| Self::hash(v, state)),
+            ValueSend::Map(v) => {
+                v.iter()
+                    .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
+                    .for_each(|(k, v)| {
+                        k.hash(state);
+                        Self::hash(v, state);
+                    });
+            }
+            ValueSend::Cartesian2D(spatial::Cartesian2D { srid, coordinates }) => {
+                srid.hash(state);
+                coordinates
+                    .iter()
+                    .map(|v| v.to_bits())
+                    .for_each(|v| v.hash(state));
+            }
+            ValueSend::Cartesian3D(spatial::Cartesian3D { srid, coordinates }) => {
+                srid.hash(state);
+                coordinates
+                    .iter()
+                    .map(|v| v.to_bits())
+                    .for_each(|v| v.hash(state));
+            }
+            ValueSend::WGS84_2D(spatial::WGS84_2D { srid, coordinates }) => {
+                srid.hash(state);
+                coordinates
+                    .iter()
+                    .map(|v| v.to_bits())
+                    .for_each(|v| v.hash(state));
+            }
+            ValueSend::WGS84_3D(spatial::WGS84_3D { srid, coordinates }) => {
+                srid.hash(state);
+                coordinates
+                    .iter()
+                    .map(|v| v.to_bits())
+                    .for_each(|v| v.hash(state));
+            }
+            ValueSend::Duration(v) => v.hash(state),
+            ValueSend::LocalTime(v) => v.hash(state),
+            ValueSend::Time(v) => v.hash(state),
+            ValueSend::Date(v) => v.hash(state),
+            ValueSend::LocalDateTime(v) => v.hash(state),
+            ValueSend::DateTime(v) => v.hash(state),
+            ValueSend::DateTimeFixed(v) => v.hash(state),
+        }
+    }
+}
+
+impl HomeDbCacheKey {
+    pub(super) fn new(
+        imp_user: Option<&Arc<String>>,
+        session_auth: Option<&Arc<AuthToken>>,
+    ) -> Self {
+        if let Some(user) = imp_user {
+            HomeDbCacheKey::FixedUser(Arc::clone(user))
+        } else if let Some(auth) = session_auth {
+            if let Some(ValueSend::String(scheme)) = auth.data.get("scheme") {
+                if scheme == "basic" {
+                    if let Some(ValueSend::String(user)) = auth.data.get("principal") {
+                        return HomeDbCacheKey::FixedUser(Arc::new(user.clone()));
+                    }
+                }
+            }
+            HomeDbCacheKey::SessionAuth(SessionAuthKey(Arc::clone(auth)))
+        } else {
+            HomeDbCacheKey::DriverUser
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HomeDbCacheEntry {
+    database: Arc<String>,
+    last_used: Instant,
+}

--- a/neo4j/src/driver/io/bolt.rs
+++ b/neo4j/src/driver/io/bolt.rs
@@ -22,6 +22,7 @@ mod bolt5x3;
 mod bolt5x4;
 mod bolt5x6;
 mod bolt5x7;
+mod bolt5x8;
 mod bolt_state;
 mod chunk;
 mod handshake;
@@ -45,7 +46,6 @@ use std::time::Duration;
 
 use atomic_refcell::AtomicRefCell;
 use enum_dispatch::enum_dispatch;
-use log::debug;
 use usize_cast::FromUsize;
 
 use super::deadline::DeadlineIO;
@@ -63,6 +63,7 @@ use bolt5x3::{Bolt5x3, Bolt5x3StructTranslator};
 use bolt5x4::{Bolt5x4, Bolt5x4StructTranslator};
 use bolt5x6::{Bolt5x6, Bolt5x6StructTranslator};
 use bolt5x7::{Bolt5x7, Bolt5x7StructTranslator};
+use bolt5x8::{Bolt5x8, Bolt5x8StructTranslator};
 use bolt_state::{BoltState, BoltStateTracker};
 use chunk::{Chunker, Dechunker};
 pub(crate) use handshake::{open, TcpConnector};
@@ -80,70 +81,99 @@ pub(crate) use socket::{BufTcpStream, Socket};
 
 macro_rules! debug_buf_start {
     ($name:ident) => {
-        let mut $name: Option<String> = match log_enabled!(Level::Debug) {
-            true => Some(String::new()),
-            false => None,
-        };
+        let mut $name = None;
+        {
+            #![allow(unused_imports)]
+            use log::{log_enabled, Level};
+
+            if log_enabled!(Level::Debug) {
+                $name = Some(String::new());
+            }
+        }
     };
 }
 pub(crate) use debug_buf_start;
 
 macro_rules! debug_buf {
-    ($name:ident, $($args:tt)+) => {
+    ($name:ident, $($args:tt)+) => {{
+        #![allow(unused_imports)]
+        use log::{log_enabled, Level};
+
         if log_enabled!(Level::Debug) {
             $name.as_mut().unwrap().push_str(&format!($($args)*))
         };
-    }
+    }}
 }
 pub(crate) use debug_buf;
 
 macro_rules! bolt_debug_extra {
     ($meta:expr, $local_port:expr) => {
         'a: {
-            let meta = $meta;
-            // ugly format because rust-fmt is broken
-            let Ok(meta) = meta else {
-                break 'a dbg_extra($local_port, Some("!!!!"));
-            };
-            let Some(ValueReceive::String(id)) = meta.get("connection_id") else {
-                break 'a dbg_extra($local_port, None);
-            };
-            dbg_extra($local_port, Some(id))
+            {
+                #![allow(unused_imports)]
+                use crate::driver::io::bolt::dbg_extra;
+
+                use crate::value::ValueReceive;
+
+                let meta = $meta;
+                let Ok(meta) = meta else {
+                    break 'a dbg_extra($local_port, Some("!!!!"));
+                };
+                let Some(ValueReceive::String(id)) = meta.get("connection_id") else {
+                    break 'a dbg_extra($local_port, None);
+                };
+                dbg_extra($local_port, Some(id))
+            }
         }
     };
 }
 pub(crate) use bolt_debug_extra;
 
 macro_rules! debug_buf_end {
-    ($bolt:expr, $name:ident) => {
+    ($bolt:expr, $name:ident) => {{
+        #![allow(unused_imports)]
+        use log::debug;
+
+        use crate::driver::io::bolt::bolt_debug_extra;
+
         debug!(
             "{}{}",
             bolt_debug_extra!($bolt.meta.try_borrow(), $bolt.local_port),
             $name.as_ref().map(|s| s.as_str()).unwrap_or("")
         );
-    };
+    }};
 }
 pub(crate) use debug_buf_end;
 
 macro_rules! bolt_debug {
-    ($bolt:expr, $($args:tt)+) => {
+    ($bolt:expr, $($args:tt)+) => {{
+        #![allow(unused_imports)]
+        use log::debug;
+
+        use crate::driver::io::bolt::bolt_debug_extra;
+
         debug!(
             "{}{}",
             bolt_debug_extra!($bolt.meta.try_borrow(), $bolt.local_port),
             format!($($args)*)
         );
-    };
+    }};
 }
 pub(crate) use bolt_debug;
 
 macro_rules! socket_debug {
-    ($local_port:expr, $($args:tt)+) => {
+    ($local_port:expr, $($args:tt)+) => {{
+        #![allow(unused_imports)]
+        use log::debug;
+
+        use crate::driver::io::bolt::dbg_extra;
+
         debug!(
             "{}{}",
             dbg_extra(Some($local_port), None),
             format!($($args)*)
         );
-    };
+    }};
 }
 pub(crate) use socket_debug;
 
@@ -179,6 +209,7 @@ impl<RW: Read + Write> Bolt<RW> {
             data: BoltData::new(version, stream, socket, local_port, address),
             // [bolt-version-bump] search tag when changing bolt version support
             protocol: match version {
+                (5, 8) => Bolt5x8::<Bolt5x8StructTranslator>::default().into(),
                 (5, 7) => Bolt5x7::<Bolt5x7StructTranslator>::default().into(),
                 (5, 6) => Bolt5x6::<Bolt5x6StructTranslator>::default().into(),
                 (5, 4) => Bolt5x4::<Bolt5x4StructTranslator>::default().into(),
@@ -392,6 +423,10 @@ impl<RW: Read + Write> Bolt<RW> {
         self.data.set_telemetry_enabled(enabled)
     }
 
+    pub(crate) fn ssr_enabled(&self) -> bool {
+        self.data.ssr_enabled()
+    }
+
     #[inline(always)]
     pub(crate) fn debug_log(&self, msg: impl FnOnce() -> String) {
         bolt_debug!(self.data, "{}", msg());
@@ -488,14 +523,15 @@ trait BoltProtocol: Debug {
 #[enum_dispatch(BoltProtocol)]
 #[derive(Debug)]
 enum BoltProtocolVersion {
-    V4x4(Bolt4x4<Bolt4x4StructTranslator>),
-    V5x0(Bolt5x0<Bolt5x0StructTranslator>),
-    V5x1(Bolt5x1<Bolt5x1StructTranslator>),
-    V5x2(Bolt5x2<Bolt5x2StructTranslator>),
-    V5x3(Bolt5x3<Bolt5x3StructTranslator>),
-    V5x4(Bolt5x4<Bolt5x4StructTranslator>),
-    V5x6(Bolt5x6<Bolt5x6StructTranslator>),
+    V5x8(Bolt5x8<Bolt5x8StructTranslator>),
     V5x7(Bolt5x7<Bolt5x7StructTranslator>),
+    V5x6(Bolt5x6<Bolt5x6StructTranslator>),
+    V5x4(Bolt5x4<Bolt5x4StructTranslator>),
+    V5x3(Bolt5x3<Bolt5x3StructTranslator>),
+    V5x2(Bolt5x2<Bolt5x2StructTranslator>),
+    V5x1(Bolt5x1<Bolt5x1StructTranslator>),
+    V5x0(Bolt5x0<Bolt5x0StructTranslator>),
+    V4x4(Bolt4x4<Bolt4x4StructTranslator>),
 }
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -517,6 +553,7 @@ pub(crate) struct BoltData<RW: Read + Write> {
     meta: Arc<AtomicRefCell<HashMap<String, ValueReceive>>>,
     server_agent: Arc<AtomicRefCell<Arc<String>>>,
     telemetry_enabled: Arc<AtomicRefCell<bool>>,
+    ssr_enabled: Arc<AtomicRefCell<bool>>,
     address: Arc<Address>,
     last_qid: Arc<AtomicRefCell<Option<i64>>>,
     auth: Option<Arc<AuthToken>>,
@@ -547,6 +584,7 @@ impl<RW: Read + Write> BoltData<RW> {
             meta: Default::default(),
             server_agent: Default::default(),
             telemetry_enabled: Default::default(),
+            ssr_enabled: Default::default(),
             address,
             last_qid: Default::default(),
             auth: None,
@@ -713,6 +751,10 @@ impl<RW: Read + Write> BoltData<RW> {
 
     fn set_telemetry_enabled(&mut self, enabled: bool) {
         *self.telemetry_enabled.borrow_mut() = enabled;
+    }
+
+    fn ssr_enabled(&self) -> bool {
+        *(*self.ssr_enabled).borrow()
     }
 }
 

--- a/neo4j/src/driver/io/bolt.rs
+++ b/neo4j/src/driver/io/bolt.rs
@@ -523,15 +523,15 @@ trait BoltProtocol: Debug {
 #[enum_dispatch(BoltProtocol)]
 #[derive(Debug)]
 enum BoltProtocolVersion {
-    V5x8(Bolt5x8<Bolt5x8StructTranslator>),
-    V5x7(Bolt5x7<Bolt5x7StructTranslator>),
-    V5x6(Bolt5x6<Bolt5x6StructTranslator>),
-    V5x4(Bolt5x4<Bolt5x4StructTranslator>),
-    V5x3(Bolt5x3<Bolt5x3StructTranslator>),
-    V5x2(Bolt5x2<Bolt5x2StructTranslator>),
-    V5x1(Bolt5x1<Bolt5x1StructTranslator>),
-    V5x0(Bolt5x0<Bolt5x0StructTranslator>),
     V4x4(Bolt4x4<Bolt4x4StructTranslator>),
+    V5x0(Bolt5x0<Bolt5x0StructTranslator>),
+    V5x1(Bolt5x1<Bolt5x1StructTranslator>),
+    V5x2(Bolt5x2<Bolt5x2StructTranslator>),
+    V5x3(Bolt5x3<Bolt5x3StructTranslator>),
+    V5x4(Bolt5x4<Bolt5x4StructTranslator>),
+    V5x6(Bolt5x6<Bolt5x6StructTranslator>),
+    V5x7(Bolt5x7<Bolt5x7StructTranslator>),
+    V5x8(Bolt5x8<Bolt5x8StructTranslator>),
 }
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]

--- a/neo4j/src/driver/io/bolt/bolt4x4/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt4x4/protocol.rs
@@ -21,7 +21,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use log::{debug, log_enabled, warn, Level};
+use log::warn;
 use usize_cast::FromUsize;
 
 use super::super::bolt5x0::Bolt5x0;
@@ -36,9 +36,8 @@ use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
 use super::super::{
-    bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol,
-    BoltResponse, BoltStructTranslatorWithUtcPatch, OnServerErrorCb, ResponseCallbacks,
-    ResponseMessage,
+    debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol, BoltResponse,
+    BoltStructTranslatorWithUtcPatch, OnServerErrorCb, ResponseCallbacks, ResponseMessage,
 };
 use crate::error_::Result;
 use crate::value::ValueReceive;

--- a/neo4j/src/driver/io/bolt/bolt5x0/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x0/protocol.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use atomic_refcell::AtomicRefCell;
-use log::{debug, log_enabled, warn, Level};
+use log::warn;
 use usize_cast::FromUsize;
 
 use super::super::bolt_common::{unsupported_protocol_feature_error, ServerAwareBoltVersion};
@@ -38,9 +38,9 @@ use super::super::packstream::{
     PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
 use super::super::{
-    assert_response_field_count, bolt_debug, bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end,
-    debug_buf_start, BoltData, BoltMeta, BoltProtocol, BoltResponse, BoltStructTranslator,
-    ConnectionState, OnServerErrorCb, ResponseCallbacks, ResponseMessage,
+    assert_response_field_count, bolt_debug, debug_buf, debug_buf_end, debug_buf_start, BoltData,
+    BoltMeta, BoltProtocol, BoltResponse, BoltStructTranslator, ConnectionState, OnServerErrorCb,
+    ResponseCallbacks, ResponseMessage,
 };
 use crate::driver::config::auth::AuthToken;
 use crate::driver::config::notification::NotificationFilter;
@@ -709,7 +709,12 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x0<T> {
 
         Self::write_mode_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, mode)?;
 
-        Self::write_db_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, db)?;
+        Self::write_db_entry(
+            log_buf.as_mut(),
+            &mut serializer,
+            &mut dbg_serializer,
+            db.as_deref().map(String::as_str),
+        )?;
 
         Self::write_imp_user_entry(
             log_buf.as_mut(),
@@ -833,7 +838,12 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x0<T> {
 
         Self::write_mode_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, mode)?;
 
-        Self::write_db_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, db)?;
+        Self::write_db_entry(
+            log_buf.as_mut(),
+            &mut serializer,
+            &mut dbg_serializer,
+            db.as_deref().map(String::as_str),
+        )?;
 
         Self::write_imp_user_entry(
             log_buf.as_mut(),

--- a/neo4j/src/driver/io/bolt/bolt5x0/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x0/protocol.rs
@@ -709,12 +709,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x0<T> {
 
         Self::write_mode_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, mode)?;
 
-        Self::write_db_entry(
-            log_buf.as_mut(),
-            &mut serializer,
-            &mut dbg_serializer,
-            db.as_deref().map(String::as_str),
-        )?;
+        Self::write_db_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, db)?;
 
         Self::write_imp_user_entry(
             log_buf.as_mut(),

--- a/neo4j/src/driver/io/bolt/bolt5x1/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x1/protocol.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 use std::io::{Read, Write};
 use std::sync::Arc;
 
-use log::{debug, log_enabled, Level};
 use usize_cast::FromUsize;
 
 use super::super::bolt5x0::Bolt5x0;
@@ -32,9 +31,8 @@ use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
 use super::super::{
-    bolt_debug, bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData,
-    BoltProtocol, BoltResponse, BoltStructTranslator, OnServerErrorCb, ResponseCallbacks,
-    ResponseMessage,
+    bolt_debug, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol, BoltResponse,
+    BoltStructTranslator, OnServerErrorCb, ResponseCallbacks, ResponseMessage,
 };
 use crate::driver::config::auth::AuthToken;
 use crate::error_::Result;

--- a/neo4j/src/driver/io/bolt/bolt5x2/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x2/protocol.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 use std::io::{Read, Write};
 
 use crate::driver::notification::NotificationFilter;
-use log::{debug, log_enabled, Level};
 use usize_cast::FromUsize;
 
 use super::super::bolt5x0::Bolt5x0;
@@ -33,8 +32,8 @@ use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
 use super::super::{
-    bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol,
-    BoltResponse, BoltStructTranslator, OnServerErrorCb, ResponseCallbacks, ResponseMessage,
+    debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol, BoltResponse,
+    BoltStructTranslator, OnServerErrorCb, ResponseCallbacks, ResponseMessage,
 };
 use crate::error_::Result;
 use crate::value::ValueReceive;
@@ -301,7 +300,12 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x2<T> {
             mode,
         )?;
 
-        Bolt5x0::<T>::write_db_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, db)?;
+        Bolt5x0::<T>::write_db_entry(
+            log_buf.as_mut(),
+            &mut serializer,
+            &mut dbg_serializer,
+            db.as_deref().map(String::as_str),
+        )?;
 
         Bolt5x0::<T>::write_imp_user_entry(
             log_buf.as_mut(),
@@ -436,11 +440,11 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x2<T> {
         if let Some(db) = db {
             debug_buf!(log_buf, "{}", {
                 dbg_serializer.write_string("db").unwrap();
-                dbg_serializer.write_string(db).unwrap();
+                dbg_serializer.write_string(&db).unwrap();
                 dbg_serializer.flush()
             });
             serializer.write_string("db")?;
-            serializer.write_string(db)?;
+            serializer.write_string(&db)?;
         }
 
         if let Some(imp_user) = imp_user {

--- a/neo4j/src/driver/io/bolt/bolt5x2/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x2/protocol.rs
@@ -300,12 +300,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x2<T> {
             mode,
         )?;
 
-        Bolt5x0::<T>::write_db_entry(
-            log_buf.as_mut(),
-            &mut serializer,
-            &mut dbg_serializer,
-            db.as_deref().map(String::as_str),
-        )?;
+        Bolt5x0::<T>::write_db_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer, db)?;
 
         Bolt5x0::<T>::write_imp_user_entry(
             log_buf.as_mut(),

--- a/neo4j/src/driver/io/bolt/bolt5x4/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x4/protocol.rs
@@ -22,7 +22,7 @@ use std::net::TcpStream;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use log::{debug, log_enabled, warn, Level};
+use log::warn;
 
 use super::super::bolt5x0::Bolt5x0;
 use super::super::bolt5x2::Bolt5x2;
@@ -38,9 +38,8 @@ use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
 use super::super::{
-    bolt_debug_extra, dbg_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltMeta,
-    BoltProtocol, BoltResponse, BoltStructTranslator, OnServerErrorCb, ResponseCallbacks,
-    ResponseMessage,
+    debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltMeta, BoltProtocol, BoltResponse,
+    BoltStructTranslator, OnServerErrorCb, ResponseCallbacks, ResponseMessage,
 };
 use crate::error_::Result;
 use crate::value::ValueReceive;

--- a/neo4j/src/driver/io/bolt/bolt5x7/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x7/protocol.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::io::{Read, Write};
 
 use crate::error::ServerError;
-use log::{debug, warn};
+use log::warn;
 
 use super::super::bolt5x6::Bolt5x6;
 use super::super::bolt_common::ServerAwareBoltVersion;
@@ -30,8 +30,8 @@ use super::super::message_parameters::{
 };
 use super::super::response::BoltMeta;
 use super::super::{
-    assert_response_field_count, bolt_debug, bolt_debug_extra, dbg_extra, BoltData, BoltProtocol,
-    BoltStructTranslator, OnServerErrorCb, ResponseCallbacks,
+    assert_response_field_count, bolt_debug, BoltData, BoltProtocol, BoltStructTranslator,
+    OnServerErrorCb, ResponseCallbacks,
 };
 use crate::error_::Result;
 use crate::value::ValueReceive;

--- a/neo4j/src/driver/io/bolt/bolt5x8.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x8.rs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod bolt;
-pub(crate) mod deadline;
-mod pool;
-mod varint;
+mod protocol;
+mod translator;
 
-#[cfg(feature = "_internal_testkit_backend")]
-pub use pool::ConnectionPoolMetrics;
-pub(crate) use pool::{
-    AcquireConfig, Pool, PoolConfig, PooledBolt, SessionAuth, UpdateRtArgs, UpdateRtDb,
-};
+pub(crate) use protocol::Bolt5x8;
+pub(crate) use translator::Bolt5x8StructTranslator;

--- a/neo4j/src/driver/io/bolt/bolt5x8/protocol.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x8/protocol.rs
@@ -13,15 +13,19 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::{Read, Write};
+use std::mem;
+use std::net::TcpStream;
+use std::ops::Deref;
+use std::sync::Arc;
 
-use super::super::bolt5x0::Bolt5x0;
-use super::super::bolt5x2::Bolt5x2;
-use super::super::bolt_common::{
-    ServerAwareBoltVersion, BOLT_AGENT_LANGUAGE, BOLT_AGENT_LANGUAGE_DETAILS, BOLT_AGENT_PLATFORM,
-    BOLT_AGENT_PRODUCT,
-};
+use crate::driver::io::bolt::bolt5x4::Bolt5x4;
+use crate::driver::io::bolt::{BoltResponse, ResponseMessage};
+use log::{debug, log_enabled, warn};
+
+use super::super::bolt_common::ServerAwareBoltVersion;
 use super::super::message::BoltMessage;
 use super::super::message_parameters::{
     BeginParameters, CommitParameters, DiscardParameters, GoodbyeParameters, HelloParameters,
@@ -31,66 +35,97 @@ use super::super::message_parameters::{
 use super::super::packstream::{
     PackStreamSerializer, PackStreamSerializerDebugImpl, PackStreamSerializerImpl,
 };
+use super::super::response::BoltMeta;
+use super::super::{bolt5x0::Bolt5x0, bolt5x2::Bolt5x2, bolt5x3::Bolt5x3, bolt5x7::Bolt5x7};
 use super::super::{
-    debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol, BoltStructTranslator,
-    OnServerErrorCb, ResponseCallbacks,
+    bolt_debug_extra, debug_buf, debug_buf_end, debug_buf_start, BoltData, BoltProtocol,
+    BoltStructTranslator, OnServerErrorCb, ResponseCallbacks,
 };
 use crate::error_::Result;
 use crate::value::ValueReceive;
 
+const HINTS_KEY: &str = "hints";
+const SSR_ENABLED_KEY: &str = "ssr.enabled";
+
 #[derive(Debug)]
-pub(crate) struct Bolt5x3<T: BoltStructTranslator> {
-    pub(in super::super) bolt5x2: Bolt5x2<T>,
+pub(crate) struct Bolt5x8<T: BoltStructTranslator> {
+    pub(in super::super) bolt5x7: Bolt5x7<T>,
 }
 
-impl<T: BoltStructTranslator> Bolt5x3<T> {
+impl<T: BoltStructTranslator> Bolt5x8<T> {
     pub(in super::super) fn new(protocol_version: ServerAwareBoltVersion) -> Self {
         Self {
-            bolt5x2: Bolt5x2::new(protocol_version),
+            bolt5x7: Bolt5x7::new(protocol_version),
         }
     }
 
-    pub(in super::super) fn write_bolt_agent_entry(
-        mut log_buf: Option<&mut String>,
-        serializer: &mut PackStreamSerializerImpl<impl Write>,
-        dbg_serializer: &mut PackStreamSerializerDebugImpl,
-    ) -> Result<()> {
-        serializer.write_string("bolt_agent")?;
-        serializer.write_dict_header(4)?;
-        serializer.write_string("product")?;
-        serializer.write_string(BOLT_AGENT_PRODUCT)?;
-        serializer.write_string("platform")?;
-        serializer.write_string(BOLT_AGENT_PLATFORM)?;
-        serializer.write_string("language")?;
-        serializer.write_string(BOLT_AGENT_LANGUAGE)?;
-        serializer.write_string("language_details")?;
-        serializer.write_string(BOLT_AGENT_LANGUAGE_DETAILS)?;
-        debug_buf!(log_buf, "{}", {
-            dbg_serializer.write_string("bolt_agent").unwrap();
-            dbg_serializer.write_dict_header(4).unwrap();
-            dbg_serializer.write_string("product").unwrap();
-            dbg_serializer.write_string(BOLT_AGENT_PRODUCT).unwrap();
-            dbg_serializer.write_string("platform").unwrap();
-            dbg_serializer.write_string(BOLT_AGENT_PLATFORM).unwrap();
-            dbg_serializer.write_string("language").unwrap();
-            dbg_serializer.write_string(BOLT_AGENT_LANGUAGE).unwrap();
-            dbg_serializer.write_string("language_details").unwrap();
-            dbg_serializer
-                .write_string(BOLT_AGENT_LANGUAGE_DETAILS)
-                .unwrap();
-            dbg_serializer.flush()
-        });
-        Ok(())
+    pub(in super::super) fn enqueue_hello_response(data: &mut BoltData<impl Read + Write>) {
+        let bolt_meta = Arc::clone(&data.meta);
+        let telemetry_enabled = Arc::clone(&data.telemetry_enabled);
+        let ssr_enabled = Arc::clone(&data.ssr_enabled);
+        let bolt_server_agent = Arc::clone(&data.server_agent);
+        let socket = Arc::clone(&data.socket);
+
+        data.responses.push_back(BoltResponse::new(
+            ResponseMessage::Hello,
+            ResponseCallbacks::new().with_on_success(move |mut meta| {
+                Bolt5x0::<T>::hello_response_handle_agent(&mut meta, &bolt_server_agent);
+                Self::hello_response_handle_connection_hints(
+                    &meta,
+                    socket.deref().as_ref(),
+                    &mut telemetry_enabled.borrow_mut(),
+                    &mut ssr_enabled.borrow_mut(),
+                );
+                mem::swap(&mut *bolt_meta.borrow_mut(), &mut meta);
+                Ok(())
+            }),
+        ));
+    }
+
+    pub(in super::super) fn hello_response_handle_connection_hints(
+        meta: &BoltMeta,
+        socket: Option<&TcpStream>,
+        telemetry_enabled: &mut bool,
+        ssr_enabled: &mut bool,
+    ) {
+        let empty_hints = HashMap::new();
+        let hints = match meta.get(HINTS_KEY) {
+            Some(ValueReceive::Map(hints)) => hints,
+            Some(value) => {
+                warn!("Server sent unexpected {HINTS_KEY} type {:?}", value);
+                &empty_hints
+            }
+            None => &empty_hints,
+        };
+        Bolt5x0::<T>::hello_response_handle_timeout_hint(hints, socket);
+        Bolt5x4::<T>::hello_response_telemetry_hint(hints, telemetry_enabled);
+        Self::hello_response_handle_ssr_enabled_hint(hints, ssr_enabled);
+    }
+
+    pub(in super::super) fn hello_response_handle_ssr_enabled_hint(
+        hints: &HashMap<String, ValueReceive>,
+        ssr_enabled: &mut bool,
+    ) {
+        match hints.get(SSR_ENABLED_KEY) {
+            None => {
+                *ssr_enabled = false;
+            }
+            Some(ValueReceive::Boolean(value)) => *ssr_enabled = *value,
+            Some(value) => {
+                *ssr_enabled = false;
+                warn!("Server sent unexpected {SSR_ENABLED_KEY} type {:?}", value);
+            }
+        }
     }
 }
 
-impl<T: BoltStructTranslator> Default for Bolt5x3<T> {
+impl<T: BoltStructTranslator> Default for Bolt5x8<T> {
     fn default() -> Self {
-        Self::new(ServerAwareBoltVersion::V5x3)
+        Self::new(ServerAwareBoltVersion::V5x8)
     }
 }
 
-impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
+impl<T: BoltStructTranslator> BoltProtocol for Bolt5x8<T> {
     fn hello<RW: Read + Write>(
         &mut self,
         data: &mut BoltData<RW>,
@@ -126,15 +161,26 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
             user_agent,
         )?;
 
-        Self::write_bolt_agent_entry(log_buf.as_mut(), &mut serializer, &mut dbg_serializer)?;
-
-        self.bolt5x2.bolt5x1.bolt5x0.write_routing_context_entry(
+        Bolt5x3::<T>::write_bolt_agent_entry(
             log_buf.as_mut(),
             &mut serializer,
             &mut dbg_serializer,
-            data,
-            routing_context,
         )?;
+
+        self.bolt5x7
+            .bolt5x6
+            .bolt5x4
+            .bolt5x3
+            .bolt5x2
+            .bolt5x1
+            .bolt5x0
+            .write_routing_context_entry(
+                log_buf.as_mut(),
+                &mut serializer,
+                &mut dbg_serializer,
+                data,
+                routing_context,
+            )?;
 
         Bolt5x2::<T>::write_notification_filter_entries(
             log_buf.as_mut(),
@@ -146,7 +192,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data.message_buff.push_back(vec![message_buff]);
         debug_buf_end!(data, log_buf);
 
-        Bolt5x0::<T>::enqueue_hello_response(data);
+        Self::enqueue_hello_response(data);
         Ok(())
     }
 
@@ -156,12 +202,12 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: ReauthParameters,
     ) -> Result<()> {
-        self.bolt5x2.reauth(data, parameters)
+        self.bolt5x7.reauth(data, parameters)
     }
 
     #[inline]
     fn supports_reauth(&self) -> bool {
-        self.bolt5x2.supports_reauth()
+        self.bolt5x7.supports_reauth()
     }
 
     #[inline]
@@ -170,7 +216,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: GoodbyeParameters,
     ) -> Result<()> {
-        self.bolt5x2.goodbye(data, parameters)
+        self.bolt5x7.goodbye(data, parameters)
     }
 
     #[inline]
@@ -179,7 +225,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: ResetParameters,
     ) -> Result<()> {
-        self.bolt5x2.reset(data, parameters)
+        self.bolt5x7.reset(data, parameters)
     }
 
     #[inline]
@@ -189,7 +235,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: RunParameters<KP, KM>,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.run(data, parameters, callbacks)
+        self.bolt5x7.run(data, parameters, callbacks)
     }
 
     #[inline]
@@ -199,7 +245,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: DiscardParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.discard(data, parameters, callbacks)
+        self.bolt5x7.discard(data, parameters, callbacks)
     }
 
     #[inline]
@@ -209,7 +255,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: PullParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.pull(data, parameters, callbacks)
+        self.bolt5x7.pull(data, parameters, callbacks)
     }
 
     #[inline]
@@ -219,7 +265,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: BeginParameters<K>,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.begin(data, parameters, callbacks)
+        self.bolt5x7.begin(data, parameters, callbacks)
     }
 
     #[inline]
@@ -229,7 +275,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: CommitParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.commit(data, parameters, callbacks)
+        self.bolt5x7.commit(data, parameters, callbacks)
     }
 
     #[inline]
@@ -238,7 +284,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         data: &mut BoltData<RW>,
         parameters: RollbackParameters,
     ) -> Result<()> {
-        self.bolt5x2.rollback(data, parameters)
+        self.bolt5x7.rollback(data, parameters)
     }
 
     #[inline]
@@ -248,7 +294,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: RouteParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.route(data, parameters, callbacks)
+        self.bolt5x7.route(data, parameters, callbacks)
     }
 
     #[inline]
@@ -258,12 +304,12 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         parameters: TelemetryParameters,
         callbacks: ResponseCallbacks,
     ) -> Result<()> {
-        self.bolt5x2.telemetry(data, parameters, callbacks)
+        self.bolt5x7.telemetry(data, parameters, callbacks)
     }
 
     #[inline]
     fn load_value<R: Read>(&mut self, reader: &mut R) -> Result<ValueReceive> {
-        self.bolt5x2.load_value(reader)
+        self.bolt5x7.load_value(reader)
     }
 
     #[inline]
@@ -273,7 +319,7 @@ impl<T: BoltStructTranslator> BoltProtocol for Bolt5x3<T> {
         message: BoltMessage<ValueReceive>,
         on_server_error: OnServerErrorCb<RW>,
     ) -> Result<()> {
-        self.bolt5x2
+        self.bolt5x7
             .handle_response(bolt_data, message, on_server_error)
     }
 }

--- a/neo4j/src/driver/io/bolt/bolt5x8/translator.rs
+++ b/neo4j/src/driver/io/bolt/bolt5x8/translator.rs
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod bolt;
-pub(crate) mod deadline;
-mod pool;
-mod varint;
+use super::super::bolt5x7::Bolt5x7StructTranslator;
 
-#[cfg(feature = "_internal_testkit_backend")]
-pub use pool::ConnectionPoolMetrics;
-pub(crate) use pool::{
-    AcquireConfig, Pool, PoolConfig, PooledBolt, SessionAuth, UpdateRtArgs, UpdateRtDb,
-};
+pub(crate) type Bolt5x8StructTranslator = Bolt5x7StructTranslator;

--- a/neo4j/src/driver/io/bolt/bolt_common.rs
+++ b/neo4j/src/driver/io/bolt/bolt_common.rs
@@ -114,9 +114,7 @@ pub(super) enum ServerAwareBoltVersion {
     V5x3,
     V5x4,
     V5x6,
-    #[allow(dead_code)] // bolt versions exists, not yet implemented
     V5x7,
-    #[allow(dead_code)]
     V5x8,
 }
 
@@ -124,30 +122,29 @@ impl ServerAwareBoltVersion {
     #[inline]
     fn protocol_version(&self) -> &'static str {
         match self {
-            ServerAwareBoltVersion::V4x4 => "4.4",
-            ServerAwareBoltVersion::V5x0 => "5.0",
-            ServerAwareBoltVersion::V5x1 => "5.1",
-            ServerAwareBoltVersion::V5x2 => "5.2",
-            ServerAwareBoltVersion::V5x3 => "5.3",
-            ServerAwareBoltVersion::V5x4 => "5.4",
-            ServerAwareBoltVersion::V5x6 => "5.6",
-            ServerAwareBoltVersion::V5x7 => "5.7",
-            ServerAwareBoltVersion::V5x8 => "5.8",
+            Self::V4x4 => "4.4",
+            Self::V5x0 => "5.0",
+            Self::V5x1 => "5.1",
+            Self::V5x2 => "5.2",
+            Self::V5x3 => "5.3",
+            Self::V5x4 => "5.4",
+            Self::V5x6 => "5.6",
+            Self::V5x7 => "5.7",
+            Self::V5x8 => "5.8",
         }
     }
 
     #[inline]
     fn min_server_version(&self) -> &'static str {
         match self {
-            ServerAwareBoltVersion::V4x4 => "4.4",
-            ServerAwareBoltVersion::V5x0 => "5.0",
-            ServerAwareBoltVersion::V5x1 => "5.5",
-            ServerAwareBoltVersion::V5x2 => "5.7",
-            ServerAwareBoltVersion::V5x3 => "5.9",
-            ServerAwareBoltVersion::V5x4 => "5.13",
-            ServerAwareBoltVersion::V5x6 => "5.23",
-            ServerAwareBoltVersion::V5x7 => "5.26",
-            ServerAwareBoltVersion::V5x8 => "5.26",
+            Self::V4x4 => "4.4",
+            Self::V5x0 => "5.0",
+            Self::V5x1 => "5.5",
+            Self::V5x2 => "5.7",
+            Self::V5x3 => "5.9",
+            Self::V5x4 => "5.13",
+            Self::V5x6 => "5.23",
+            Self::V5x7 | Self::V5x8 => "5.26",
         }
     }
 }

--- a/neo4j/src/driver/io/bolt/bolt_state.rs
+++ b/neo4j/src/driver/io/bolt/bolt_state.rs
@@ -15,8 +15,8 @@
 use log::debug;
 use std::collections::HashMap;
 
+use super::bolt_debug_extra;
 use super::response::ResponseMessage;
-use super::{bolt_debug_extra, dbg_extra};
 use crate::value::ValueReceive;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]

--- a/neo4j/src/driver/io/bolt/handshake.rs
+++ b/neo4j/src/driver/io/bolt/handshake.rs
@@ -37,7 +37,7 @@ const BOLT_MAGIC_PREAMBLE: [u8; 4] = [0x60, 0x60, 0xB0, 0x17];
 // [bolt-version-bump] search tag when changing bolt version support
 const BOLT_VERSION_OFFER: [u8; 16] = [
     0, 0, 1, 255, // BOLT handshake manifest v1
-    0, 1, 7, 5, // BOLT 5.7 - 5.6
+    0, 2, 8, 5, // BOLT 5.8 - 5.6
     0, 4, 4, 5, // BOLT 5.4 - 5.0
     0, 0, 4, 4, // BOLT 4.4
 ];
@@ -407,8 +407,9 @@ fn decode_version_offer(offer: &[u8; 4]) -> Result<(u8, u8)> {
 }
 
 // [bolt-version-bump] search tag when changing bolt version support
-const BOLT_VERSIONS: [(u8, u8); 8] = [
+const BOLT_VERSIONS: [(u8, u8); 9] = [
     // important: ordered by descending preference
+    (5, 8),
     (5, 7),
     (5, 6),
     (5, 4),
@@ -546,6 +547,7 @@ mod tests {
     #[case([0, 0, 4, 5], (5, 4))]
     #[case([0, 0, 6, 5], (5, 6))]
     #[case([0, 0, 7, 5], (5, 7))]
+    #[case([0, 0, 8, 5], (5, 8))]
     fn test_decode_version_offer(
         #[case] mut offer: [u8; 4],
         #[case] expected: (u8, u8),
@@ -586,7 +588,7 @@ mod tests {
     #[case([0, 0, 2, 4])] // driver didn't offer version 4.2
     #[case([0, 0, 3, 4])] // driver didn't offer version 4.3
     #[case([0, 0, 5, 5])] // driver didn't offer version 5.5
-    #[case([0, 0, 8, 5])] // driver didn't offer version 5.8
+    #[case([0, 0, 9, 5])] // driver didn't offer version 5.8
     #[case([0, 0, 0, 6])] // driver didn't offer version 6.0
     fn test_garbage_server_version(
         #[case] mut offer: [u8; 4],

--- a/neo4j/src/driver/io/bolt/message_parameters.rs
+++ b/neo4j/src/driver/io/bolt/message_parameters.rs
@@ -76,7 +76,7 @@ impl ResetParameters {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct RunParameters<'a, KP: Borrow<str> + Debug, KM: Borrow<str> + Debug> {
     pub(super) query: &'a str,
     pub(super) parameters: Option<&'a HashMap<KP, ValueSend>>,
@@ -84,7 +84,7 @@ pub(crate) struct RunParameters<'a, KP: Borrow<str> + Debug, KM: Borrow<str> + D
     pub(super) tx_timeout: Option<i64>,
     pub(super) tx_metadata: Option<&'a HashMap<KM, ValueSend>>,
     pub(super) mode: Option<&'a str>,
-    pub(super) db: Option<&'a str>,
+    pub(super) db: Option<Arc<String>>,
     pub(super) imp_user: Option<&'a str>,
     pub(super) notification_filter: Option<&'a NotificationFilter>,
 }
@@ -98,7 +98,7 @@ impl<'a, KP: Borrow<str> + Debug, KM: Borrow<str> + Debug> RunParameters<'a, KP,
         tx_timeout: Option<i64>,
         tx_metadata: Option<&'a HashMap<KM, ValueSend>>,
         mode: Option<&'a str>,
-        db: Option<&'a str>,
+        db: Option<Arc<String>>,
         imp_user: Option<&'a str>,
         notification_filter: &'a NotificationFilter,
     ) -> Self {
@@ -159,13 +159,13 @@ impl PullParameters {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct BeginParameters<'a, K: Borrow<str> + Debug> {
     pub(super) bookmarks: Option<&'a Bookmarks>,
     pub(super) tx_timeout: Option<i64>,
     pub(super) tx_metadata: Option<&'a HashMap<K, ValueSend>>,
     pub(super) mode: Option<&'a str>,
-    pub(super) db: Option<&'a str>,
+    pub(super) db: Option<Arc<String>>,
     pub(super) imp_user: Option<&'a str>,
     pub(super) notification_filter: &'a NotificationFilter,
 }
@@ -176,7 +176,7 @@ impl<'a, K: Borrow<str> + Debug> BeginParameters<'a, K> {
         tx_timeout: Option<i64>,
         tx_metadata: Option<&'a HashMap<K, ValueSend>>,
         mode: Option<&'a str>,
-        db: Option<&'a str>,
+        db: Option<Arc<String>>,
         imp_user: Option<&'a str>,
         notification_filter: &'a NotificationFilter,
     ) -> Self {

--- a/neo4j/src/driver/io/bolt/message_parameters.rs
+++ b/neo4j/src/driver/io/bolt/message_parameters.rs
@@ -84,7 +84,7 @@ pub(crate) struct RunParameters<'a, KP: Borrow<str> + Debug, KM: Borrow<str> + D
     pub(super) tx_timeout: Option<i64>,
     pub(super) tx_metadata: Option<&'a HashMap<KM, ValueSend>>,
     pub(super) mode: Option<&'a str>,
-    pub(super) db: Option<Arc<String>>,
+    pub(super) db: Option<&'a str>,
     pub(super) imp_user: Option<&'a str>,
     pub(super) notification_filter: Option<&'a NotificationFilter>,
 }
@@ -98,7 +98,7 @@ impl<'a, KP: Borrow<str> + Debug, KM: Borrow<str> + Debug> RunParameters<'a, KP,
         tx_timeout: Option<i64>,
         tx_metadata: Option<&'a HashMap<KM, ValueSend>>,
         mode: Option<&'a str>,
-        db: Option<Arc<String>>,
+        db: Option<&'a str>,
         imp_user: Option<&'a str>,
         notification_filter: &'a NotificationFilter,
     ) -> Self {

--- a/neo4j/src/driver/io/pool/routing.rs
+++ b/neo4j/src/driver/io/pool/routing.rs
@@ -40,8 +40,8 @@ pub(crate) struct RoutingTable {
 impl RoutingTable {
     pub(crate) fn new(initial_router: Arc<Address>) -> Self {
         Self {
-            routers: Vec::new(),
-            readers: vec![initial_router],
+            routers: vec![initial_router],
+            readers: Vec::new(),
             writers: Vec::new(),
             database: None,
             initialized_without_writers: true,

--- a/neo4j/src/driver/io/pool/ssr_tracker.rs
+++ b/neo4j/src/driver/io/pool/ssr_tracker.rs
@@ -1,0 +1,86 @@
+// Copyright Rouven Bauer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::{Read, Write};
+use std::sync::atomic::AtomicUsize;
+
+use super::super::bolt::Bolt;
+
+#[derive(Debug, Default)]
+pub(crate) struct SsrTracker {
+    with_ssr: AtomicUsize,
+    without_ssr: AtomicUsize,
+}
+
+impl SsrTracker {
+    pub(super) fn new() -> Self {
+        Default::default()
+    }
+
+    fn with_ssr(&self) -> usize {
+        self.with_ssr.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn increment_with_ssr(&self) {
+        self.with_ssr
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn decrement_with_ssr(&self) {
+        self.with_ssr
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn increment_without_ssr(&self) {
+        self.without_ssr
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn decrement_without_ssr(&self) {
+        self.without_ssr
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn without_ssr(&self) -> usize {
+        self.without_ssr.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(super) fn add_connection(&self, connection: &impl SsrTrackable) {
+        match connection.ssr_enabled() {
+            true => self.increment_with_ssr(),
+            false => self.increment_without_ssr(),
+        }
+    }
+
+    pub(super) fn remove_connection(&self, connection: &impl SsrTrackable) {
+        match connection.ssr_enabled() {
+            true => self.decrement_with_ssr(),
+            false => self.decrement_without_ssr(),
+        }
+    }
+
+    pub(super) fn ssr_enabled(&self) -> bool {
+        self.with_ssr() > 0 && self.without_ssr() == 0
+    }
+}
+
+pub(super) trait SsrTrackable {
+    fn ssr_enabled(&self) -> bool;
+}
+
+impl<RW: Read + Write> SsrTrackable for Bolt<RW> {
+    fn ssr_enabled(&self) -> bool {
+        self.ssr_enabled()
+    }
+}

--- a/neo4j/src/driver/session.rs
+++ b/neo4j/src/driver/session.rs
@@ -169,7 +169,7 @@ impl<'driver> Session<'driver> {
                     builder.timeout.raw(),
                     Some(builder.meta.borrow()),
                     builder.mode.as_protocol_str(),
-                    target_db,
+                    target_db.as_deref().map(String::as_str),
                     self.config
                         .config
                         .as_ref()

--- a/neo4j/src/driver/session.rs
+++ b/neo4j/src/driver/session.rs
@@ -25,23 +25,25 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::result::Result as StdResult;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use log::{debug, info};
 
 use super::config::auth::AuthToken;
+use super::home_db_cache::{HomeDbCache, HomeDbCacheKey};
 use super::io::bolt::message_parameters::{
     BeginParameters, RunParameters, TelemetryAPI, TelemetryParameters,
 };
-use super::io::bolt::ResponseCallbacks;
-use super::io::{AcquireConfig, Pool, PooledBolt, UpdateRtArgs};
+use super::io::bolt::{BoltMeta, ResponseCallbacks};
+use super::io::{AcquireConfig, Pool, PooledBolt, UpdateRtArgs, UpdateRtDb};
 use super::record_stream::{ErrorPropagator, RecordStream, SharedErrorPropagator};
 use super::transaction::{Transaction, TransactionTimeout};
 use super::{EagerResult, ReducedDriverConfig, RoutingControl};
 use crate::driver::io::SessionAuth;
 use crate::error_::{Neo4jError, Result};
+use crate::time::Instant;
 use crate::transaction::InnerTransaction;
-use crate::value::ValueSend;
+use crate::value::{ValueReceive, ValueSend};
 use bookmarks::{bookmark_managers, BookmarkManager, Bookmarks};
 use config::InternalSessionConfig;
 pub use config::SessionConfig;
@@ -75,25 +77,35 @@ use super::Driver;
 pub struct Session<'driver> {
     config: InternalSessionConfig,
     pool: &'driver Pool,
+    home_db_cache: Arc<HomeDbCache>,
     driver_config: &'driver ReducedDriverConfig,
-    resolved_db: Option<Arc<String>>,
+    target_db: Arc<AtomicRefCell<SessionTargetDb>>,
+    home_db_cache_key: OnceLock<HomeDbCacheKey>,
     session_bookmarks: SessionBookmarks,
+    current_acquisition_deadline: Option<Instant>,
 }
 
 impl<'driver> Session<'driver> {
-    pub(crate) fn new(
+    pub(super) fn new(
         config: InternalSessionConfig,
         pool: &'driver Pool,
+        home_db_cache: Arc<HomeDbCache>,
         driver_config: &'driver ReducedDriverConfig,
     ) -> Self {
         let bookmarks = config.config.bookmarks.clone();
         let manager = config.config.as_ref().bookmark_manager.clone();
+        let target_db = Arc::new(AtomicRefCell::new(SessionTargetDb::new_init(
+            config.config.database.clone(),
+        )));
         Session {
             config,
             pool,
+            home_db_cache,
             driver_config,
-            resolved_db: None,
+            target_db,
+            home_db_cache_key: Default::default(),
             session_bookmarks: SessionBookmarks::new(bookmarks, manager),
+            current_acquisition_deadline: None,
         }
     }
 
@@ -147,23 +159,27 @@ impl<'driver> Session<'driver> {
             true,
             None,
         );
+        let target_db = AtomicRefCell::borrow(&self.target_db).as_db();
         let res = record_stream
-            .run(RunParameters::new_auto_commit_run(
-                builder.query.as_ref(),
-                Some(builder.param.borrow()),
-                Some(&*self.session_bookmarks.get_bookmarks_for_work()?),
-                builder.timeout.raw(),
-                Some(builder.meta.borrow()),
-                builder.mode.as_protocol_str(),
-                self.resolved_db().as_ref().map(|db| db.as_str()),
-                self.config
-                    .config
-                    .as_ref()
-                    .impersonated_user
-                    .as_ref()
-                    .map(|imp| imp.as_str()),
-                &self.config.config.notification_filter,
-            ))
+            .run(
+                RunParameters::new_auto_commit_run(
+                    builder.query.as_ref(),
+                    Some(builder.param.borrow()),
+                    Some(&*self.session_bookmarks.get_bookmarks_for_work()?),
+                    builder.timeout.raw(),
+                    Some(builder.meta.borrow()),
+                    builder.mode.as_protocol_str(),
+                    target_db,
+                    self.config
+                        .config
+                        .as_ref()
+                        .impersonated_user
+                        .as_ref()
+                        .map(|imp| imp.as_str()),
+                    &self.config.config.notification_filter,
+                ),
+                Some(Box::new(self.make_db_meta_resolution_cb())),
+            )
             .and_then(|_| (builder.receiver)(&mut record_stream));
         let res = match res {
             Ok(r) => {
@@ -228,7 +244,7 @@ impl<'driver> Session<'driver> {
             builder.timeout.raw(),
             Some(builder.meta.borrow()),
             builder.mode.as_protocol_str(),
-            self.resolved_db().as_ref().map(|db| db.as_str()),
+            AtomicRefCell::borrow(&self.target_db).as_db(),
             self.config
                 .config
                 .impersonated_user
@@ -236,10 +252,18 @@ impl<'driver> Session<'driver> {
                 .map(|imp| imp.as_str()),
             &self.config.config.notification_filter,
         );
+
         tx.begin(
             parameters,
             self.config.eager_begin,
             ResponseCallbacks::new()
+                .with_on_success({
+                    let db_cb = self.make_db_meta_resolution_cb();
+                    move |mut meta| {
+                        db_cb(&mut meta);
+                        Ok(())
+                    }
+                })
                 .with_on_failure(ErrorPropagator::make_on_error_cb(error_propagator)),
         )?;
         let res = receiver(Transaction::new(&mut tx));
@@ -267,9 +291,38 @@ impl<'driver> Session<'driver> {
     }
 
     fn resolve_db(&mut self) -> Result<()> {
-        if self.resolved_db().is_none() && self.pool.is_routing() {
-            debug!("Resolving home db");
-            self.resolved_db = self.pool.resolve_home_db(UpdateRtArgs {
+        let mut target_db = AtomicRefCell::borrow_mut(&self.target_db);
+        if target_db.pinned
+            || target_db
+                .target
+                .as_ref()
+                .map(|t| !t.guess)
+                .unwrap_or_default()
+            || !self.pool.is_routing()
+        {
+            debug!(
+                "Targeting fixed db: {:?}",
+                target_db.target.as_ref().map(|t| t.db.as_str())
+            );
+            target_db.pinned = true;
+            return Ok(());
+        }
+        if self.pool.ssr_enabled() {
+            if let Some(cached_db) = self.home_db_cache.get(self.home_db_cache_key()) {
+                debug!("Targeting cached home db: {:?}", cached_db.as_str());
+                *target_db = SessionTargetDb::new_guess(cached_db);
+                return Ok(());
+            }
+        }
+        drop(target_db);
+
+        self.resolve_db_forced()
+    }
+
+    fn resolve_db_forced(&mut self) -> Result<()> {
+        debug!("Resolving home db");
+        self.pool
+            .resolve_home_db(UpdateRtArgs {
                 db: None,
                 bookmarks: Some(&*self.session_bookmarks.get_bookmarks_for_work()?),
                 imp_user: self
@@ -279,40 +332,132 @@ impl<'driver> Session<'driver> {
                     .as_ref()
                     .map(|imp| imp.as_str()),
                 session_auth: self.session_auth(),
+                deadline: self.current_acquisition_deadline,
                 idle_time_before_connection_test: self.config.idle_time_before_connection_test,
-            })?;
-            debug!("Resolved home db to {:?}", &self.resolved_db);
-        }
-        Ok(())
+                db_resolution_cb: Some(&self.make_db_resolution_cb()),
+            })
+            .map(|_| ())
     }
 
-    #[inline]
-    fn resolved_db(&self) -> &Option<Arc<String>> {
-        match self.resolved_db {
-            None => &self.config.config.database,
-            Some(_) => &self.resolved_db,
+    fn make_db_meta_resolution_cb(&self) -> impl Fn(&mut BoltMeta) + Send + Sync + 'static {
+        let base_cb = self.make_db_resolution_cb();
+        move |meta| {
+            let db = match meta.remove("db") {
+                Some(ValueReceive::String(db)) => Some(Arc::new(db)),
+                _ => None,
+            };
+            base_cb(db);
         }
+    }
+
+    fn make_db_resolution_cb_if_needed(
+        &self,
+    ) -> Option<impl Fn(Option<Arc<String>>) + Send + Sync + 'static> {
+        if !self.pool.is_routing() {
+            return None;
+        }
+        {
+            let target_db = AtomicRefCell::borrow(&self.target_db);
+            if target_db.pinned || !target_db.target.as_ref().map(|t| t.guess).unwrap_or(true) {
+                return None;
+            }
+        };
+        Some(self.make_db_resolution_cb())
+    }
+
+    fn make_db_resolution_cb(&self) -> impl Fn(Option<Arc<String>>) + Send + Sync + 'static {
+        let cache = Arc::clone(&self.home_db_cache);
+        let target_db = Arc::clone(&self.target_db);
+        let key = self.home_db_cache_key().clone();
+        move |db| {
+            if let Some(db) = db.as_ref() {
+                cache.update(key.clone(), Arc::clone(db));
+            }
+            {
+                let mut target_db = AtomicRefCell::borrow_mut(&target_db);
+                if !target_db.pinned {
+                    debug!("Pinning db: {:?}", db.as_ref().map(|d| d.as_str()));
+                    *target_db = SessionTargetDb::new_pinned(db);
+                }
+            }
+        }
+    }
+
+    fn home_db_cache_key(&self) -> &HomeDbCacheKey {
+        self.home_db_cache_key.get_or_init(|| {
+            HomeDbCacheKey::new(
+                self.config.config.impersonated_user.as_ref(),
+                self.config.config.auth.as_ref(),
+            )
+        })
     }
 
     pub(super) fn acquire_connection(
         &mut self,
         mode: RoutingControl,
     ) -> Result<PooledBolt<'driver>> {
+        self.acquire_connection_args(mode, AcquireArgs::default())
+    }
+
+    fn acquire_connection_args(
+        &mut self,
+        mode: RoutingControl,
+        args: AcquireArgs,
+    ) -> Result<PooledBolt<'driver>> {
+        self.current_acquisition_deadline = self.pool.config.connection_acquisition_deadline();
         self.resolve_db()?;
         let bookmarks = self.session_bookmarks.get_bookmarks_for_work()?;
+        let target = AtomicRefCell::borrow(&self.target_db).target.clone();
+        let connection = self.no_resolve_acquire_connection(
+            mode,
+            Some(&*bookmarks),
+            target.as_ref(),
+            args.session_auth.unwrap_or_else(|| self.session_auth()),
+        )?;
+        if target.as_ref().map(|t| t.guess).unwrap_or_default() && !connection.ssr_enabled() {
+            debug!(
+                "Used db cached, received connection without SSR => \
+                    returning connection and falling back to explicit db resolution"
+            );
+            drop(connection);
+            self.resolve_db_forced()?;
+            let target = AtomicRefCell::borrow(&self.target_db).target.clone();
+            self.no_resolve_acquire_connection(
+                mode,
+                Some(&*bookmarks),
+                target.as_ref(),
+                args.session_auth.unwrap_or_else(|| self.session_auth()),
+            )
+        } else {
+            Ok(connection)
+        }
+    }
+
+    fn no_resolve_acquire_connection(
+        &self,
+        mode: RoutingControl,
+        bookmarks: Option<&Bookmarks>,
+        db: Option<&UpdateRtDb>,
+        session_auth: SessionAuth,
+    ) -> Result<PooledBolt<'driver>> {
         self.pool.acquire(AcquireConfig {
             mode,
             update_rt_args: UpdateRtArgs {
-                db: self.resolved_db().as_ref(),
-                bookmarks: Some(&*bookmarks),
+                db,
+                bookmarks,
                 imp_user: self
                     .config
                     .config
                     .impersonated_user
                     .as_ref()
                     .map(|imp| imp.as_str()),
-                session_auth: self.session_auth(),
+                session_auth,
+                deadline: self.current_acquisition_deadline,
                 idle_time_before_connection_test: self.config.idle_time_before_connection_test,
+                db_resolution_cb: self
+                    .make_db_resolution_cb_if_needed()
+                    .as_ref()
+                    .map(|cb| cb as _),
             },
         })
     }
@@ -338,23 +483,10 @@ impl<'driver> Session<'driver> {
     }
 
     fn forced_auth(&mut self, auth: &Arc<AuthToken>) -> Result<()> {
-        self.resolve_db()?;
-        let bookmarks = self.session_bookmarks.get_bookmarks_for_work()?;
-        let mut connection = self.pool.acquire(AcquireConfig {
-            mode: RoutingControl::Read,
-            update_rt_args: UpdateRtArgs {
-                db: self.resolved_db().as_ref(),
-                bookmarks: Some(&*bookmarks),
-                imp_user: self
-                    .config
-                    .config
-                    .impersonated_user
-                    .as_ref()
-                    .map(|imp| imp.as_str()),
-                session_auth: SessionAuth::Forced(auth),
-                idle_time_before_connection_test: self.config.idle_time_before_connection_test,
-            },
-        })?;
+        let args = AcquireArgs {
+            session_auth: Some(SessionAuth::Forced(auth)),
+        };
+        let mut connection = self.acquire_connection_args(RoutingControl::Read, args)?;
         connection.write_all(None)?;
         connection.read_all(None)
     }
@@ -1133,5 +1265,47 @@ impl SessionBookmarks {
             }
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct AcquireArgs<'a> {
+    session_auth: Option<SessionAuth<'a>>,
+}
+
+#[derive(Debug, Default)]
+struct SessionTargetDb {
+    target: Option<UpdateRtDb>,
+    pinned: bool,
+}
+
+impl SessionTargetDb {
+    fn new_init(target: Option<Arc<String>>) -> Self {
+        Self {
+            target: target.map(|db| UpdateRtDb { db, guess: false }),
+            pinned: false,
+        }
+    }
+
+    fn new_guess(db: Arc<String>) -> Self {
+        Self {
+            target: Some(UpdateRtDb { db, guess: true }),
+            pinned: false,
+        }
+    }
+
+    fn new_pinned(target: Option<Arc<String>>) -> Self {
+        Self {
+            target: target.map(|db| UpdateRtDb { db, guess: false }),
+            pinned: true,
+        }
+    }
+
+    fn as_db(&self) -> Option<Arc<String>> {
+        if self.pinned || self.target.as_ref().map(|t| !t.guess).unwrap_or_default() {
+            self.target.as_ref().map(|t| Arc::clone(&t.db))
+        } else {
+            None
+        }
     }
 }

--- a/neo4j/src/driver/transaction.rs
+++ b/neo4j/src/driver/transaction.rs
@@ -249,7 +249,10 @@ impl<'driver> InnerTransaction<'driver> {
             false,
             Some(Arc::clone(&self.error_propagator)),
         );
-        record_stream.run(RunParameters::new_transaction_run(query, Some(parameters)))?;
+        record_stream.run(
+            RunParameters::new_transaction_run(query, Some(parameters)),
+            None,
+        )?;
         Ok(record_stream)
     }
 

--- a/neo4j/src/lib.rs
+++ b/neo4j/src/lib.rs
@@ -23,10 +23,12 @@
 //!
 //! ## Compatibility
 // [bolt-version-bump] search tag when changing bolt version support
-//! This driver supports bolt protocol version 4.4, and 5.0 - 5.7.
-//! This corresponds to Neo4j versions 4.4, and 5.0 - 5.26+.
+//! This driver supports bolt protocol version 4.4, and 5.0 - 5.8.
+//! This corresponds to Neo4j versions 4.4, and the whole 5.x series.
+//! Newer versions of Neo4j are supported as long as they keep support for at least one of the
+//! protocol versions mentioned above.
 //! For details of bolt protocol compatibility, see the
-//! [official Neo4j documentation](https://neo4j.com/docs/bolt/current/bolt-compatibility/).
+//! [official Neo4j documentation](https://7687.org/bolt-compatibility/).
 //!
 //! ## Basic Example
 //! ```

--- a/neo4j/src/test_data/public-api.txt
+++ b/neo4j/src/test_data/public-api.txt
@@ -738,7 +738,7 @@ pub fn neo4j::session::Session<'driver>::last_bookmarks(&self) -> alloc::sync::A
 pub fn neo4j::session::Session<'driver>::transaction<'session>(&'session mut self) -> neo4j::session::TransactionBuilder<'driver, 'session, alloc::string::String, std::collections::hash::map::HashMap<alloc::string::String, neo4j::ValueSend>>
 impl<'driver> core::fmt::Debug for neo4j::session::Session<'driver>
 pub fn neo4j::session::Session<'driver>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'driver> core::marker::Freeze for neo4j::session::Session<'driver>
+impl<'driver> !core::marker::Freeze for neo4j::session::Session<'driver>
 impl<'driver> core::marker::Send for neo4j::session::Session<'driver>
 impl<'driver> core::marker::Sync for neo4j::session::Session<'driver>
 impl<'driver> core::marker::Unpin for neo4j::session::Session<'driver>

--- a/neo4j/src/value/value_send.rs
+++ b/neo4j/src/value/value_send.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use super::spatial;
 use super::time;
 use super::value_receive::ValueReceive;
 use super::ValueConversionError;
+use itertools::Itertools;
+use std::collections::HashMap;
 
 // imports for docs
 #[allow(unused)]
@@ -73,7 +73,8 @@ impl ValueSend {
             ValueSend::Map(v1) => match other {
                 ValueSend::Map(v2) if v1.len() == v2.len() => v1
                     .iter()
-                    .zip(v2.iter())
+                    .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
+                    .zip(v2.iter().sorted_by(|(k1, _), (k2, _)| k1.cmp(k2)))
                     .all(|((k1, v1), (k2, v2))| k1 == k2 && v1.eq_data(v2)),
                 _ => false,
             },

--- a/testkit_backend/src/testkit_backend/requests.rs
+++ b/testkit_backend/src/testkit_backend/requests.rs
@@ -75,6 +75,7 @@ pub(super) enum Request {
         fetch_size: Option<i64>,
         max_tx_retry_time_ms: Option<u64>,
         liveness_check_timeout_ms: Option<u64>,
+        max_connection_lifetime_ms: Option<u64>,
         max_connection_pool_size: Option<usize>,
         connection_acquisition_timeout_ms: Option<u64>,
         #[serde(rename = "clientCertificate")]
@@ -818,6 +819,7 @@ impl Request {
             fetch_size,
             max_tx_retry_time_ms,
             liveness_check_timeout_ms,
+            max_connection_lifetime_ms,
             max_connection_pool_size,
             connection_acquisition_timeout_ms,
             client_certificate,
@@ -884,6 +886,10 @@ impl Request {
         if let Some(timeout) = liveness_check_timeout_ms {
             driver_config =
                 driver_config.with_idle_time_before_connection_test(Duration::from_millis(timeout));
+        }
+        if let Some(timeout) = max_connection_lifetime_ms {
+            driver_config =
+                driver_config.with_max_connection_lifetime(Duration::from_millis(timeout));
         }
         if let Some(max_connection_pool_size) = max_connection_pool_size {
             driver_config = driver_config.with_max_connection_pool_size(max_connection_pool_size);

--- a/testkit_backend/src/testkit_backend/responses.rs
+++ b/testkit_backend/src/testkit_backend/responses.rs
@@ -37,7 +37,7 @@ use super::{BackendId, TestKitResultT};
 
 // [bolt-version-bump] search tag when changing bolt version support
 // https://github.com/rust-lang/rust/issues/85077
-const FEATURE_LIST: [&str; 48] = [
+const FEATURE_LIST: [&str; 52] = [
     // === FUNCTIONAL FEATURES ===
     "Feature:API:BookmarkManager",
     "Feature:API:ConnectionAcquisitionTimeout",
@@ -45,9 +45,7 @@ const FEATURE_LIST: [&str; 48] = [
     // "Feature:API:Driver.ExecuteQuery:WithAuth",
     "Feature:API:Driver:GetServerInfo",
     "Feature:API:Driver.IsEncrypted",
-    // "Feature:API:Driver:MaxConnectionLifetime",
-    // Even tough the driver does not support notification config,
-    // TestKit uses this flag to change assertions on the notification objects
+    "Feature:API:Driver:MaxConnectionLifetime",
     "Feature:API:Driver:NotificationsConfig",
     "Feature:API:Driver.VerifyAuthentication",
     "Feature:API:Driver.VerifyConnectivity",
@@ -83,7 +81,7 @@ const FEATURE_LIST: [&str; 48] = [
     // "Feature:Bolt:5.5",  // unused/deprecated protocol version
     "Feature:Bolt:5.6",
     "Feature:Bolt:5.7",
-    // "Feature:Bolt:5.8",
+    "Feature:Bolt:5.8",
     "Feature:Bolt:HandshakeManifestV1",
     "Feature:Bolt:Patch:UTC",
     "Feature:Impersonation",
@@ -97,8 +95,8 @@ const FEATURE_LIST: [&str; 48] = [
     "Optimization:ConnectionReuse",
     "Optimization:EagerTransactionBegin",
     "Optimization:ExecuteQueryPipelining",
-    // "Optimization:HomeDatabaseCache",
-    // "Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser",
+    "Optimization:HomeDatabaseCache",
+    "Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser",
     "Optimization:ImplicitDefaultArguments",
     "Optimization:MinimalBookmarksSet",
     "Optimization:MinimalResets",
@@ -130,6 +128,14 @@ fn get_plain_skipped_tests() -> &'static HashMap<&'static str, &'static str> {
             (
                 "stub.summary.test_summary.TestSummaryNotifications4x4.test_no_notifications",
                 "An empty list is returned when there are no notifications",
+            ),
+            (
+                "stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_route_response",
+                "Pending driver unification: only some drivers consider a single connection acquisition timeout for all operations on acquisition (like fetching routing table) and some consider a separate timeout for each operation",
+            ),
+            (
+                "stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_router_handshake_has_own_timeout_in_time",
+                "Pending driver unification: only some drivers consider a single connection acquisition timeout for all operations on acquisition (like fetching routing table) and some consider a separate timeout for each operation",
             ),
             (
                 "neo4j.test_summary.TestSummary.test_no_notification_info",


### PR DESCRIPTION
Introducing support for Bolt 5.8, which (among other things) makes the server echo back the resolved home/default db on starting a transaction as well as a connection hint whether server-side routing (SSR) is enabled. If so, the echoed db can be used together with an optimistic home db cache to guess a client-side route (optimistic routing - falling back to SSR on wrong guesses). This feature saves a round-trip under the following conditions (*all* must be fulfilled):
 * Server has SSR enabled
 * Sever supports Bolt 5.8
 * A fresh (yet unused) session without an explicitly configured target database starts its first transaction (auto-commit or explicit)
 * There is a cache entry for the current user.
   How exactly "current user" is defined is left as an implementation detail. Currently, this is in order of descending precedence:
    * the impersonated user if any
    * else the session auth token (for basic auth, only the principal is considered) if any
    * else some fallback key representing the driver-level user.