### PR TITLE
Fix some clippy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ***
 **👏️ Improvements**
  - Reduce network latency in some cases by setting `TCP_NODELAY`.
+ - ⚠️ Reduce the size of `Neo4jError`. The `ServerError` variant is now wrapped in a Box.
 
 
 ## 0.2.0

--- a/doc_test_utils/src/lib.rs
+++ b/doc_test_utils/src/lib.rs
@@ -116,7 +116,7 @@ pub fn error_retryable() -> Neo4jResult<()> {
         Ok(()) => panic!("Expected an error"),
         Err(err) if err.is_retryable() => Err(err),
         Err(err) => {
-            panic!("Expected a retryable error, got: {}", err);
+            panic!("Expected a retryable error, got: {err}");
         }
     }
 }
@@ -134,7 +134,7 @@ pub fn error_non_retryable() -> Neo4jResult<()> {
         Ok(()) => panic!("Expected an error"),
         Err(err) if !err.is_retryable() => Err(err),
         Err(err) => {
-            panic!("Expected a non-retryable error, got: {}", err);
+            panic!("Expected a non-retryable error, got: {err}");
         }
     }
 }

--- a/neo4j/build.rs
+++ b/neo4j/build.rs
@@ -28,7 +28,7 @@ fn get_rustc_version() -> String {
             "`{} --version` {}\n\n--- stdout\n{}\n--- stderr{}",
             &rustc,
             match rust_version.status.code() {
-                Some(code) => format!("exited with status code {}", code),
+                Some(code) => format!("exited with status code {code}"),
                 None => String::from("was killed killed by signal"),
             },
             String::from_utf8_lossy(rust_version.stdout.as_slice()),
@@ -47,33 +47,27 @@ fn main() {
         "neo4j-rust-robsdedude/{}",
         env::var("CARGO_PKG_VERSION").unwrap()
     );
-    println!("Setting bolt agent product to: {}", product);
+    println!("Setting bolt agent product to: {product}");
 
     let platform = env::var("TARGET").unwrap();
-    println!("Setting bolt agent platform to: {}", platform);
+    println!("Setting bolt agent platform to: {platform}");
 
-    let language = format!("Rust/{}", rustc_version);
-    println!("Setting bolt agent language to: {}", language);
+    let language = format!("Rust/{rustc_version}");
+    println!("Setting bolt agent language to: {language}");
 
     let language_details = format!(
         "profile: {}; host: {}",
         env::var("PROFILE").unwrap(),
         env::var("HOST").unwrap()
     );
-    println!(
-        "Setting bolt agent language details to: {}",
-        language_details
-    );
+    println!("Setting bolt agent language details to: {language_details}");
 
-    let user_agent = format!("{} {} {}", product, language, platform);
-    println!("Setting default user agent to: {}", user_agent);
+    let user_agent = format!("{product} {language} {platform}");
+    println!("Setting default user agent to: {user_agent}");
 
-    println!("cargo:rustc-env=NEO4J_DEFAULT_USER_AGENT={}", user_agent);
-    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_PRODUCT={}", product);
-    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_PLATFORM={}", platform);
-    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_LANGUAGE={}", language);
-    println!(
-        "cargo:rustc-env=NEO4J_BOLT_AGENT_LANGUAGE_DETAILS={}",
-        language_details
-    );
+    println!("cargo:rustc-env=NEO4J_DEFAULT_USER_AGENT={user_agent}");
+    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_PRODUCT={product}");
+    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_PLATFORM={platform}");
+    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_LANGUAGE={language}");
+    println!("cargo:rustc-env=NEO4J_BOLT_AGENT_LANGUAGE_DETAILS={language_details}");
 }

--- a/neo4j/src/address_/resolution.rs
+++ b/neo4j/src/address_/resolution.rs
@@ -78,7 +78,7 @@ impl CustomResolution {
                         Ok(Self::Resolver(addrs))
                     }
                     Err(err) => {
-                        debug!("custom resolver failed: {:?}", err);
+                        debug!("custom resolver failed: {err:?}");
                         Err(Neo4jError::UserCallback {
                             error: UserCallbackError::Resolver(err),
                         })
@@ -157,7 +157,7 @@ impl DnsResolution {
                     );
                 }
                 Err(err) => {
-                    debug!("dns resolver out: {:?}", err);
+                    debug!("dns resolver out: {err:?}");
                 }
             }
             Self::RealResolution(Some(res))

--- a/neo4j/src/driver/config.rs
+++ b/neo4j/src/driver/config.rs
@@ -753,9 +753,8 @@ impl ConnectionConfig {
             "bolt+ssc" => (false, Some(tls_helper::self_signed_tls_config())),
             scheme => {
                 return Err(ConnectionConfigParseError(format!(
-                    "unknown scheme in URI {} expected `neo4j`, `neo4j`, `neo4j+s`, `neo4j+ssc`, \
-                         `bolt`, `bolt+s`, or `bolt+ssc`",
-                    scheme
+                    "unknown scheme in URI {scheme} expected `neo4j`, `neo4j`, `neo4j+s`, \
+                     `neo4j+ssc`, `bolt`, `bolt+s`, or `bolt+ssc`"
                 )))
             }
         };
@@ -801,8 +800,7 @@ impl ConnectionConfig {
                     if !routing {
                         return Err(ConnectionConfigParseError(format!(
                             "URI with bolt scheme cannot contain a query \
-                                                  (routing context), found: {}",
-                            query,
+                             (routing context), found: {query}",
                         )));
                     }
                     Some(Self::parse_query(query)?)
@@ -812,8 +810,7 @@ impl ConnectionConfig {
 
         if let Some(fragment) = uri.fragment() {
             return Err(ConnectionConfigParseError(format!(
-                "URI cannot contain a fragment, found: {}",
-                fragment
+                "URI cannot contain a fragment, found: {fragment}"
             )));
         }
 
@@ -834,16 +831,14 @@ impl ConnectionConfig {
             let mut elements: Vec<_> = key_value.split('=').take(3).collect();
             if elements.len() != 2 {
                 return Err(ConnectionConfigParseError(format!(
-                    "couldn't parse key=value pair '{}' in '{}'",
-                    key_value, query
+                    "couldn't parse key=value pair '{key_value}' in '{query}'"
                 )));
             }
             let value = elements.pop().unwrap();
             let key = elements.pop().unwrap();
             if key == "address" {
                 return Err(ConnectionConfigParseError(format!(
-                    "routing context cannot contain key 'address', found: {}",
-                    value
+                    "routing context cannot contain key 'address', found: {value}"
                 )));
             }
             result.insert(key.into(), value.into());
@@ -1316,7 +1311,7 @@ mod tests {
         #[case] uri_query: &str,
         #[case] routing_context: HashMap<String, ValueSend>,
     ) {
-        let uri: String = format!("{}{}", uri_base, uri_query);
+        let uri: String = format!("{uri_base}{uri_query}");
         dbg!(&uri, &routing_context);
         let connection_config = ConnectionConfig::try_from(uri.as_str());
         let connection_config = connection_config.unwrap();

--- a/neo4j/src/driver/home_db_cache.rs
+++ b/neo4j/src/driver/home_db_cache.rs
@@ -123,7 +123,7 @@ pub(super) enum HomeDbCacheKey {
 impl HomeDbCacheKey {
     fn log_str(&self) -> String {
         match self {
-            HomeDbCacheKey::DriverUser | HomeDbCacheKey::FixedUser(_) => format!("{:?}", self),
+            HomeDbCacheKey::DriverUser | HomeDbCacheKey::FixedUser(_) => format!("{self:?}"),
             HomeDbCacheKey::SessionAuth(SessionAuthKey(auth)) => {
                 let mut auth: AuthToken = (**auth).clone();
                 auth.data

--- a/neo4j/src/driver/io/bolt.rs
+++ b/neo4j/src/driver/io/bolt.rs
@@ -248,7 +248,7 @@ impl<RW: Read + Write> Bolt<RW> {
                 ServerAwareBoltVersion::V4x4,
                 Bolt4x4::<Bolt4x4StructTranslator>::default().into(),
             ),
-            _ => panic!("implement protocol for version {:?}", version),
+            _ => panic!("implement protocol for version {version:?}"),
         };
         let data = BoltData::new(
             version,

--- a/neo4j/src/driver/io/bolt/bolt_handler/hello_4x4.rs
+++ b/neo4j/src/driver/io/bolt/bolt_handler/hello_4x4.rs
@@ -168,7 +168,7 @@ impl HelloHandler4x4 {
                     }
                 }
                 _ => {
-                    warn!("Server sent unexpected {PATCH_BOLT_KEY} type {:?}", value);
+                    warn!("Server sent unexpected {PATCH_BOLT_KEY} type {value:?}");
                 }
             }
         }

--- a/neo4j/src/driver/io/bolt/bolt_handler/hello_5x0.rs
+++ b/neo4j/src/driver/io/bolt/bolt_handler/hello_5x0.rs
@@ -188,7 +188,7 @@ impl HelloHandler5x0 {
         match meta.get(HINTS_KEY) {
             Some(ValueReceive::Map(hints)) => Cow::Borrowed(hints),
             Some(value) => {
-                warn!("Server sent unexpected {HINTS_KEY} type {:?}", value);
+                warn!("Server sent unexpected {HINTS_KEY} type {value:?}");
                 Cow::Owned(HashMap::new())
             }
             None => Cow::Owned(HashMap::new()),

--- a/neo4j/src/driver/io/bolt/bolt_handler/hello_5x0.rs
+++ b/neo4j/src/driver/io/bolt/bolt_handler/hello_5x0.rs
@@ -164,7 +164,7 @@ impl HelloHandler5x0 {
         if let Some((key, value)) = meta.remove_entry(SERVER_AGENT_KEY) {
             match value {
                 ValueReceive::String(value) => {
-                    mem::swap(&mut *bolt_server_agent.borrow_mut(), &mut Arc::new(value));
+                    *bolt_server_agent.borrow_mut() = Arc::new(value);
                 }
                 _ => {
                     warn!("Server sent unexpected server_agent type {:?}", &value);

--- a/neo4j/src/driver/io/bolt/bolt_handler/hello_5x4.rs
+++ b/neo4j/src/driver/io/bolt/bolt_handler/hello_5x4.rs
@@ -145,10 +145,7 @@ impl HelloHandler5x4 {
             return;
         };
         let ValueReceive::Boolean(enabled) = enabled else {
-            warn!(
-                "Server sent unexpected {TELEMETRY_ENABLED_KEY} type {:?}",
-                enabled
-            );
+            warn!("Server sent unexpected {TELEMETRY_ENABLED_KEY} type {enabled:?}");
             return;
         };
         // since client didn't opt out, leave it up to the server

--- a/neo4j/src/driver/io/bolt/bolt_handler/hello_5x8.rs
+++ b/neo4j/src/driver/io/bolt/bolt_handler/hello_5x8.rs
@@ -90,7 +90,7 @@ impl HelloHandler5x8 {
             Some(ValueReceive::Boolean(value)) => *ssr_enabled = *value,
             Some(value) => {
                 *ssr_enabled = false;
-                warn!("Server sent unexpected {SSR_ENABLED_KEY} type {:?}", value);
+                warn!("Server sent unexpected {SSR_ENABLED_KEY} type {value:?}");
             }
         }
     }

--- a/neo4j/src/driver/io/bolt/bolt_handler/run_5x0.rs
+++ b/neo4j/src/driver/io/bolt/bolt_handler/run_5x0.rs
@@ -155,8 +155,7 @@ impl RunHandler5x0 {
                     Ok(())
                 }
                 Some(v) => Err(Neo4jError::protocol_error(format!(
-                    "server send non-int qid: {:?}",
-                    v
+                    "server send non-int qid: {v:?}"
                 ))),
             }
         })

--- a/neo4j/src/driver/io/bolt/bolt_state.rs
+++ b/neo4j/src/driver/io/bolt/bolt_state.rs
@@ -109,27 +109,27 @@ impl BoltStateTracker {
                 }
             }
             BoltState::Failed => {}
-            _ => panic!("unexpected hello for {:?}", self),
+            _ => panic!("unexpected hello for {self:?}"),
         }
     }
 
     fn update_logon(&mut self) {
         match self.state {
             BoltState::Authenticating => self.state = BoltState::Ready,
-            _ => panic!("unexpected logon for {:?}", self),
+            _ => panic!("unexpected logon for {self:?}"),
         }
     }
 
     fn update_logoff(&mut self) {
         match self.state {
             BoltState::Ready => self.state = BoltState::Authenticating,
-            _ => panic!("unexpected logoff for {:?}", self),
+            _ => panic!("unexpected logoff for {self:?}"),
         }
     }
 
     fn update_reset(&mut self) {
         match self.state {
-            BoltState::Connected => panic!("unexpected reset for {:?}", self),
+            BoltState::Connected => panic!("unexpected reset for {self:?}"),
             _ => self.state = BoltState::Ready,
         }
     }
@@ -138,7 +138,7 @@ impl BoltStateTracker {
             BoltState::Ready => self.state = BoltState::Streaming,
             BoltState::TxReady => self.state = BoltState::TxMaybeStreaming,
             BoltState::TxMaybeStreaming => {} // stay in same state
-            _ => panic!("unexpected run for {:?}", self),
+            _ => panic!("unexpected run for {self:?}"),
         }
     }
 
@@ -146,7 +146,7 @@ impl BoltStateTracker {
         match self.state {
             BoltState::Streaming => self.state = BoltState::Ready,
             BoltState::TxMaybeStreaming => {} // stay in same state
-            _ => panic!("unexpected discard for {:?}", self),
+            _ => panic!("unexpected discard for {self:?}"),
         }
     }
 
@@ -154,35 +154,35 @@ impl BoltStateTracker {
         match self.state {
             BoltState::Streaming => self.state = BoltState::Ready,
             BoltState::TxMaybeStreaming => {} // stay in same state
-            _ => panic!("unexpected discard for {:?}", self),
+            _ => panic!("unexpected discard for {self:?}"),
         }
     }
 
     fn update_begin(&mut self) {
         match self.state {
             BoltState::Ready => self.state = BoltState::TxReady,
-            _ => panic!("unexpected begin for {:?}", self),
+            _ => panic!("unexpected begin for {self:?}"),
         }
     }
 
     fn update_commit(&mut self) {
         match self.state {
             BoltState::TxReady | BoltState::TxMaybeStreaming => self.state = BoltState::Ready,
-            _ => panic!("unexpected commit for {:?}", self),
+            _ => panic!("unexpected commit for {self:?}"),
         }
     }
 
     fn update_rollback(&mut self) {
         match self.state {
             BoltState::TxReady | BoltState::TxMaybeStreaming => self.state = BoltState::Ready,
-            _ => panic!("unexpected rollback for {:?}", self),
+            _ => panic!("unexpected rollback for {self:?}"),
         }
     }
 
     fn update_route(&mut self) {
         match self.state {
             BoltState::Ready => {} // stay in same state
-            _ => panic!("unexpected route for {:?}", self),
+            _ => panic!("unexpected route for {self:?}"),
         }
     }
 }

--- a/neo4j/src/driver/io/bolt/chunk.rs
+++ b/neo4j/src/driver/io/bolt/chunk.rs
@@ -101,11 +101,11 @@ impl Deref for Chunk<'_> {
     fn deref(&self) -> &Self::Target {
         match self {
             Chunk::Buffer(buf) => {
-                trace!("C: <RAW> {:02X?}", buf);
+                trace!("C: <RAW> {buf:02X?}");
                 buf
             }
             Chunk::Size(size) => {
-                trace!("C: <RAW> {:02X?}", size);
+                trace!("C: <RAW> {size:02X?}");
                 size
             }
         }
@@ -154,7 +154,7 @@ impl<R: Read> Read for Dechunker<R> {
             if log_enabled!(Level::Trace) {
                 let log_raw = self.chunk_log_raw.as_mut().unwrap();
                 if !log_raw.is_empty() {
-                    trace!("{}]", log_raw);
+                    trace!("{log_raw}]");
                     log_raw.clear();
                 }
                 if self.chunk_size > 0 {
@@ -196,7 +196,7 @@ impl<R: Read> Drop for Dechunker<R> {
         if log_enabled!(Level::Trace) {
             let log_raw = self.chunk_log_raw.as_mut().unwrap();
             if !log_raw.is_empty() {
-                trace!("{}]", log_raw);
+                trace!("{log_raw}]");
             }
         }
         if self.chunk_size > 0 && !self.broken {

--- a/neo4j/src/driver/io/bolt/chunk.rs
+++ b/neo4j/src/driver/io/bolt/chunk.rs
@@ -173,7 +173,7 @@ impl<R: Read> Read for Dechunker<R> {
         if log_enabled!(Level::Trace) && res.is_ok() {
             let log_raw = self.chunk_log_raw.as_mut().unwrap();
             log_raw.push_str(", ");
-            log_raw.push_str(truncate_string(&format!("{:02X?}", buf), 1, 1));
+            log_raw.push_str(truncate_string(&format!("{buf:02X?}"), 1, 1));
         }
         self.chunk_size -= new_buf_size;
         self.error_wrap(res)

--- a/neo4j/src/driver/io/bolt/handshake.rs
+++ b/neo4j/src/driver/io/bolt/handshake.rs
@@ -194,7 +194,7 @@ pub(crate) fn open<S: SocketProvider>(
     let raw_socket = socket_provider
         .set_tcp_keepalive(raw_socket, keep_alive)
         .map_err(|err| Neo4jError::InvalidConfig {
-            message: format!("failed to set tcp keepalive: {}", err),
+            message: format!("failed to set tcp keepalive: {err}"),
         })?;
     let local_port = socket_provider.get_local_port(&raw_socket);
 
@@ -350,7 +350,7 @@ fn handshake_manifest_v1<S: SocketProvider>(
         offering_count,
         raw_version_offerings
             .iter()
-            .map(|offering| format!("{:#010X}", offering))
+            .map(|offering| format!("{offering:#010X}"))
             .join(" "),
         capabilities,
     );
@@ -398,13 +398,12 @@ fn decode_version_offer(offer: &[u8; 4]) -> Result<(u8, u8)> {
             // "HTTP"
             Err(Neo4jError::InvalidConfig {
                 message: format!(
-                    "unexpected server handshake response {:?} (looks like HTTP)",
-                    offer
+                    "unexpected server handshake response {offer:?} (looks like HTTP)"
                 ),
             })
         }
         _ => Err(Neo4jError::InvalidConfig {
-            message: format!("unexpected server handshake response {:?}", offer),
+            message: format!("unexpected server handshake response {offer:?}"),
         }),
     }
 }
@@ -564,7 +563,7 @@ mod tests {
     fn test_unsupported_server_version() {
         let res = decode_version_offer(&[0, 0, 0, 0]);
         let Err(Neo4jError::InvalidConfig { message }) = res else {
-            panic!("Expected InvalidConfig error, got {:?}", res);
+            panic!("Expected InvalidConfig error, got {res:?}");
         };
         let message = message.to_lowercase();
         assert!(message.contains("server version not supported"));
@@ -574,7 +573,7 @@ mod tests {
     fn test_server_version_looks_like_http() {
         let res = decode_version_offer(&[72, 84, 84, 80]);
         let Err(Neo4jError::InvalidConfig { message }) = res else {
-            panic!("Expected InvalidConfig error, got {:?}", res);
+            panic!("Expected InvalidConfig error, got {res:?}");
         };
         let message = message.to_lowercase();
         assert!(message.contains("unexpected server handshake response"));
@@ -600,7 +599,7 @@ mod tests {
         offer[0..2].copy_from_slice(&garbage);
         let res = decode_version_offer(&offer);
         let Err(Neo4jError::InvalidConfig { message }) = res else {
-            panic!("Expected InvalidConfig error, got {:?}", res);
+            panic!("Expected InvalidConfig error, got {res:?}");
         };
         let message = message.to_lowercase();
         assert!(message.contains("unexpected server handshake response"));

--- a/neo4j/src/driver/io/bolt/handshake.rs
+++ b/neo4j/src/driver/io/bolt/handshake.rs
@@ -169,17 +169,9 @@ pub(crate) fn open<S: SocketProvider>(
     tls_config: Option<Arc<ClientConfig>>,
 ) -> Result<Bolt<Socket<S::BuffRW>>> {
     if log_enabled!(Trace) {
-        trace!(
-            "{}{}",
-            dbg_extra(None, None),
-            format!("C: <OPEN> {address:?}")
-        );
+        trace!("{}C: <OPEN> {address:?}", dbg_extra(None, None),);
     } else {
-        debug!(
-            "{}{}",
-            dbg_extra(None, None),
-            format!("C: <OPEN> {address}")
-        );
+        debug!("{}C: <OPEN> {address}", dbg_extra(None, None),);
     }
 
     let timeout = combine_connection_timout(connect_timeout, deadline);

--- a/neo4j/src/driver/io/bolt/message.rs
+++ b/neo4j/src/driver/io/bolt/message.rs
@@ -33,8 +33,7 @@ impl<V> BoltMessage<V> {
         let marker = marker[0];
         if !(0xB0..=0xBF).contains(&marker) {
             return Err(Neo4jError::protocol_error(format!(
-                "expected bolt message marker, received {:02X?}",
-                marker
+                "expected bolt message marker, received {marker:02X?}"
             )));
         }
         let size = marker - 0xB0;

--- a/neo4j/src/driver/io/bolt/packstream/error.rs
+++ b/neo4j/src/driver/io/bolt/packstream/error.rs
@@ -41,7 +41,7 @@ impl From<&str> for PackStreamSerializeError {
 
 impl From<io::Error> for PackStreamSerializeError {
     fn from(err: io::Error) -> Self {
-        let mut e: Self = format!("IO error while serializing: {}", err).into();
+        let mut e: Self = format!("IO error while serializing: {err}").into();
         e.cause = Some(err);
         e
     }
@@ -93,7 +93,7 @@ impl From<&str> for PackStreamDeserializeError {
 
 impl From<io::Error> for PackStreamDeserializeError {
     fn from(err: io::Error) -> Self {
-        let mut e: Self = format!("IO error while deserializing: {}", err).into();
+        let mut e: Self = format!("IO error while deserializing: {err}").into();
         e.cause = Some(err);
         e
     }

--- a/neo4j/src/driver/io/bolt/packstream/serialize.rs
+++ b/neo4j/src/driver/io/bolt/packstream/serialize.rs
@@ -192,13 +192,13 @@ impl PackStreamSerializerDebugImpl {
 
     #[inline]
     fn format_display<D: Display>(&mut self, data: D) {
-        self.buff += &format!("{}", data);
+        self.buff += &format!("{data}");
         self.handle_stack();
     }
 
     #[inline]
     fn format_debug<D: Debug>(&mut self, data: D) {
-        self.buff += &format!("{:?}", data);
+        self.buff += &format!("{data:?}");
         self.handle_stack();
     }
 
@@ -253,7 +253,7 @@ impl PackStreamSerializer for PackStreamSerializerDebugImpl {
     }
 
     fn write_bytes(&mut self, b: &[u8]) -> Result<(), Self::Error> {
-        self.buff += &format!("bytes{:02X?}", b);
+        self.buff += &format!("bytes{b:02X?}");
         self.handle_stack();
         Ok(())
     }
@@ -287,10 +287,10 @@ impl PackStreamSerializer for PackStreamSerializerDebugImpl {
 
     fn write_struct_header(&mut self, tag: u8, size: u8) -> Result<(), Self::Error> {
         if size > 0 {
-            self.buff += &format!("Structure[{:#02X?}; {}](", tag, size);
+            self.buff += &format!("Structure[{tag:#02X?}; {size}](");
             self.stack.push((", ", ")", size.into()));
         } else {
-            self.buff += &format!("Structure[{:#02X?}; 0]()", tag);
+            self.buff += &format!("Structure[{tag:#02X?}; 0]()");
             self.handle_stack();
         }
         Ok(())

--- a/neo4j/src/driver/io/bolt/packstream/tests.rs
+++ b/neo4j/src/driver/io/bolt/packstream/tests.rs
@@ -520,7 +520,7 @@ fn test_encode_long_dict(#[case] size: usize, #[case] header: Vec<u8>) {
     let mut input = HashMap::with_capacity(size);
     let mut bytes = Vec::with_capacity(6);
     for i in 0..size {
-        let key = format!("{:04X}", i);
+        let key = format!("{i:04X}");
         let value = i % 100;
         input.insert(key.clone(), ValueSend::Integer(value as i64));
 

--- a/neo4j/src/driver/io/bolt/response.rs
+++ b/neo4j/src/driver/io/bolt/response.rs
@@ -71,7 +71,11 @@ impl ResponseCallbacks {
             on_record_cb: None,
             on_summary_cb: None,
         }
-        .with_on_failure(|error| Err(Neo4jError::ServerError { error }))
+        .with_on_failure(|error| {
+            Err(Neo4jError::ServerError {
+                error: Box::new(error),
+            })
+        })
     }
 
     pub(crate) fn with_on_success<F: FnMut(BoltMeta) -> Result<()> + Send + Sync + 'static>(

--- a/neo4j/src/driver/io/deadline.rs
+++ b/neo4j/src/driver/io/deadline.rs
@@ -107,7 +107,7 @@ impl<'tcp, S: Read + Write> DeadlineIO<'tcp, S> {
         let res = work(self);
         let res = self.wrap_io_error(res, ReaderErrorDuring::IO);
         if let Err(err) = set_socket_timeout(socket, old_timeout) {
-            warn!("failed to restore timeout: {}", err)
+            warn!("failed to restore timeout: {err}")
         }
         res
     }

--- a/neo4j/src/driver/io/pool.rs
+++ b/neo4j/src/driver/io/pool.rs
@@ -578,7 +578,7 @@ impl RoutingPool {
         }
         match new_rt {
             Err(err) => {
-                error!("failed to update routing table; last error: {}", err);
+                error!("failed to update routing table; last error: {err}");
                 Err(Neo4jError::disconnect(format!(
                     "unable to retrieve routing information; last error: {err}"
                 )))
@@ -592,7 +592,7 @@ impl RoutingPool {
                     }
                     _ => new_rt.database.clone(),
                 };
-                debug!("Storing new routing table for {:?}: {:?}", db, new_rt);
+                debug!("Storing new routing table for {db:?}: {new_rt:?}");
                 rts.insert(db.as_ref().map(Arc::clone), new_rt);
                 self.clean_up_pools(rts);
                 if let Some(cb) = args.db_resolution_cb {
@@ -652,7 +652,7 @@ impl RoutingPool {
                     match new_rt {
                         Ok(new_rt) => res = Some(Ok(new_rt)),
                         Err(e) => {
-                            warn!("failed to parse routing table: {}", e);
+                            warn!("failed to parse routing table: {e}");
                             res = Some(Err(Neo4jError::protocol_error(format!("{e}"))));
                         }
                     }
@@ -750,7 +750,7 @@ impl RoutingPool {
     }
 
     fn deactivate_server_locked(addr: &Address, rts: &mut RoutingTables, pools: &mut RoutingPools) {
-        debug!("deactivating address: {:?}", addr);
+        debug!("deactivating address: {addr:?}");
         rts.iter_mut().for_each(|(_, rt)| rt.deactivate(addr));
         pools.remove(addr);
     }
@@ -763,7 +763,7 @@ impl RoutingPool {
     }
 
     fn deactivate_writer_locked(addr: &Address, rts: &mut RoutingTables) {
-        debug!("deactivating writer: {:?}", addr);
+        debug!("deactivating writer: {addr:?}");
         rts.iter_mut()
             .for_each(|(_, rt)| rt.deactivate_writer(addr));
     }
@@ -796,7 +796,7 @@ impl RoutingPool {
                 if e.fatal_during_discovery() {
                     Err(e)
                 } else {
-                    info!("ignored error during discovery: {:?}", e);
+                    info!("ignored error during discovery: {e:?}");
                     Ok(Err(e))
                 }
             }

--- a/neo4j/src/driver/io/pool/routing.rs
+++ b/neo4j/src/driver/io/pool/routing.rs
@@ -132,7 +132,7 @@ impl RoutingTable {
         })?;
         let role = match role.as_str().into() {
             ServerRole::Unknown => {
-                warn!("ignoring unknown server role {}", role);
+                warn!("ignoring unknown server role {role}");
                 return Ok((ServerRole::Unknown, vec![]));
             }
             role => role,
@@ -159,14 +159,11 @@ impl RoutingTable {
 
     pub(crate) fn is_fresh(&self, mode: RoutingControl) -> bool {
         if self.routers.is_empty() {
-            debug!("routing table expired: no routers left {:?}", self);
+            debug!("routing table expired: no routers left {self:?}");
             return false;
         }
         if self.servers_for_mode(mode).is_empty() {
-            debug!(
-                "routing table expired: no servers for {:?} mode left {:?}",
-                mode, self
-            );
+            debug!("routing table expired: no servers for {mode:?} mode left {self:?}");
             return false;
         }
         if self.created.elapsed() > self.ttl {
@@ -178,7 +175,7 @@ impl RoutingTable {
             );
             return false;
         }
-        debug!("routing table is fresh {:?}", self);
+        debug!("routing table is fresh {self:?}");
         true
     }
 

--- a/neo4j/src/driver/io/pool/single_pool.rs
+++ b/neo4j/src/driver/io/pool/single_pool.rs
@@ -143,13 +143,13 @@ impl InnerPool {
                     ) {
                         Ok(connection) => return Ok(connection),
                         Err(err) => {
-                            info!("failed to open connection: {}", err);
+                            info!("failed to open connection: {err}");
                             Some(Err(err))
                         }
                     }
                 }
                 Err(err) => {
-                    info!("failed to resolve address: {}", err);
+                    info!("failed to resolve address: {err}");
                     Some(Err(Neo4jError::connect_error(err)))
                 }
             }

--- a/neo4j/src/driver/io/pool/single_pool.rs
+++ b/neo4j/src/driver/io/pool/single_pool.rs
@@ -354,7 +354,7 @@ impl UnpreparedSinglePooledBolt {
                             deadline,
                             on_server_error,
                         ) {
-                            connection.debug_log(|| format!("liveness check failed: {}", err));
+                            connection.debug_log(|| format!("liveness check failed: {err}"));
                             self.bolt = Some(connection);
                             return Ok(None);
                         }

--- a/neo4j/src/driver/record_stream.rs
+++ b/neo4j/src/driver/record_stream.rs
@@ -77,7 +77,7 @@ impl<'driver> RecordStream<'driver> {
     ) -> Result<()> {
         if let RecordListenerState::ForeignError(e) = &(*self.listener).borrow().state {
             return Err(Neo4jError::ServerError {
-                error: e.deref().clone(),
+                error: e.deref().clone().into(),
             });
         }
 
@@ -139,7 +139,7 @@ impl<'driver> RecordStream<'driver> {
                     match state_swap {
                         RecordListenerState::ForeignError(e) => {
                             return Err(Neo4jError::ServerError {
-                                error: e.deref().clone(),
+                                error: e.deref().clone().into(),
                             })
                         }
                         _ => panic!("checked state to be error above"),
@@ -428,7 +428,7 @@ impl Iterator for RecordStream<'_> {
                     match state {
                         RecordListenerState::ForeignError(e) => {
                             return Some(Err(Neo4jError::ServerError {
-                                error: e.deref().clone(),
+                                error: e.deref().clone().into(),
                             }))
                         }
                         _ => panic!("checked state to be foreign error above"),
@@ -557,7 +557,9 @@ impl RecordListener {
                 "failure in a query of this transaction caused transaction to be closed",
             );
         }
-        self.state = RecordListenerState::Error(Neo4jError::ServerError { error });
+        self.state = RecordListenerState::Error(Neo4jError::ServerError {
+            error: Box::new(error),
+        });
         self.summary = None;
         Ok(())
     }

--- a/neo4j/src/driver/record_stream.rs
+++ b/neo4j/src/driver/record_stream.rs
@@ -681,7 +681,7 @@ pub enum GetSingleRecordError {
 impl From<GetSingleRecordError> for Neo4jError {
     fn from(err: GetSingleRecordError) -> Self {
         Self::InvalidConfig {
-            message: format!("GetSingleRecordError: {}", err),
+            message: format!("GetSingleRecordError: {err}"),
         }
     }
 }

--- a/neo4j/src/driver/session.rs
+++ b/neo4j/src/driver/session.rs
@@ -276,8 +276,7 @@ impl<'driver> Session<'driver> {
                 if let Err(e) = tx.close() {
                     info!(
                         "while propagating user code error: \
-                        ignored tx.close() error in transaction_run: {}",
-                        e
+                        ignored tx.close() error in transaction_run: {e}"
                     )
                 }
                 res

--- a/neo4j/src/driver/summary.rs
+++ b/neo4j/src/driver/summary.rs
@@ -116,8 +116,7 @@ impl Summary {
         if let Some(db) = meta.remove("db") {
             let ValueReceive::String(db) = db else {
                 return Err(Neo4jError::protocol_error(format!(
-                    "db in summary was not string but {:?}",
-                    db
+                    "db in summary was not string but {db:?}"
                 )));
             };
             self.database = Some(db);
@@ -268,8 +267,7 @@ impl SummaryQueryType {
         if let Some(query_type) = meta.remove("type") {
             let ValueReceive::String(query_type) = query_type else {
                 return Err(Neo4jError::protocol_error(format!(
-                    "type in summary was not string but {:?}",
-                    query_type
+                    "type in summary was not string but {query_type:?}"
                 )));
             };
             return Ok(Some(match query_type.as_str() {
@@ -279,8 +277,7 @@ impl SummaryQueryType {
                 "s" => Self::Schema,
                 _ => {
                     return Err(Neo4jError::protocol_error(format!(
-                        "query type in summary was an unknown string {:?}",
-                        query_type
+                        "query type in summary was an unknown string {query_type:?}"
                     )))
                 }
             }));
@@ -966,30 +963,30 @@ impl ServerInfo {
 
 fn try_into_bool(v: ValueReceive, context: &str) -> Result<bool> {
     v.try_into_bool()
-        .map_err(|v| Neo4jError::protocol_error(format!("{} was not bool but {:?}", context, v)))
+        .map_err(|v| Neo4jError::protocol_error(format!("{context} was not bool but {v:?}")))
 }
 
 fn try_into_int(v: ValueReceive, context: &str) -> Result<i64> {
     v.try_into_int()
-        .map_err(|v| Neo4jError::protocol_error(format!("{} was not int but {:?}", context, v)))
+        .map_err(|v| Neo4jError::protocol_error(format!("{context} was not int but {v:?}")))
 }
 
 fn try_into_float(v: ValueReceive, context: &str) -> Result<f64> {
     v.try_into_float()
-        .map_err(|v| Neo4jError::protocol_error(format!("{} was not float but {:?}", context, v)))
+        .map_err(|v| Neo4jError::protocol_error(format!("{context} was not float but {v:?}")))
 }
 
 fn try_into_string(v: ValueReceive, context: &str) -> Result<String> {
     v.try_into_string()
-        .map_err(|v| Neo4jError::protocol_error(format!("{} was not string but {:?}", context, v)))
+        .map_err(|v| Neo4jError::protocol_error(format!("{context} was not string but {v:?}")))
 }
 
 fn try_into_list(v: ValueReceive, context: &str) -> Result<Vec<ValueReceive>> {
     v.try_into_list()
-        .map_err(|v| Neo4jError::protocol_error(format!("{} was not list but {:?}", context, v)))
+        .map_err(|v| Neo4jError::protocol_error(format!("{context} was not list but {v:?}")))
 }
 
 fn try_into_map(v: ValueReceive, context: &str) -> Result<HashMap<String, ValueReceive>> {
     v.try_into_map()
-        .map_err(|v| Neo4jError::protocol_error(format!("{} was not map but {:?}", context, v)))
+        .map_err(|v| Neo4jError::protocol_error(format!("{context} was not map but {v:?}")))
 }

--- a/neo4j/src/driver/transaction.rs
+++ b/neo4j/src/driver/transaction.rs
@@ -260,7 +260,7 @@ impl<'driver> InnerTransaction<'driver> {
         match self.error_propagator.deref().borrow().error() {
             None => Ok(()),
             Some(err) => Err(Neo4jError::ServerError {
-                error: err.deref().clone(),
+                error: err.deref().clone().into(),
             }),
         }
     }

--- a/neo4j/src/error_.rs
+++ b/neo4j/src/error_.rs
@@ -154,7 +154,7 @@ impl Neo4jError {
     }
 
     pub(crate) fn read_err(err: io::Error) -> Self {
-        info!("read error: {}", err);
+        info!("read error: {err}");
         Self::Disconnect {
             message: String::from("failed to read"),
             source: Some(err),
@@ -170,7 +170,7 @@ impl Neo4jError {
     }
 
     pub(crate) fn write_error(err: io::Error) -> Neo4jError {
-        info!("write error: {}", err);
+        info!("write error: {err}");
         Self::Disconnect {
             message: String::from("failed to write"),
             source: Some(err),

--- a/neo4j/src/error_.rs
+++ b/neo4j/src/error_.rs
@@ -104,7 +104,7 @@ pub enum Neo4jError {
     ///  * the server returns an error.
     #[error("{error}")]
     #[non_exhaustive]
-    ServerError { error: ServerError },
+    ServerError { error: Box<ServerError> },
 
     /// Used when
     ///  * connection acquisition timed out

--- a/neo4j/src/error_.rs
+++ b/neo4j/src/error_.rs
@@ -427,7 +427,7 @@ impl Display for ServerError {
             self.message, self.code, self.gql_status,
         )?;
         if let Some(cause) = &self.cause {
-            write!(f, "\ncaused by: {}", cause)?;
+            write!(f, "\ncaused by: {cause}")?;
         }
         Ok(())
     }
@@ -540,7 +540,7 @@ impl Display for GqlErrorCause {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)?;
         if let Some(cause) = &self.cause {
-            write!(f, "\ncaused by: {}", cause)?;
+            write!(f, "\ncaused by: {cause}")?;
         }
         Ok(())
     }

--- a/neo4j/src/macros.rs
+++ b/neo4j/src/macros.rs
@@ -438,10 +438,10 @@ mod tests {
     fn test_float(#[case] input: ValueSend, #[case] output: ValueSend) {
         dbg!(&input, &output);
         let ValueSend::Float(input) = input else {
-            panic!("input is not float but {:?}", input);
+            panic!("input is not float but {input:?}");
         };
         let ValueSend::Float(output) = output else {
-            panic!("output is not float but {:?}", output);
+            panic!("output is not float but {output:?}");
         };
 
         if input.is_nan() {

--- a/neo4j/src/test_data/public-api.txt
+++ b/neo4j/src/test_data/public-api.txt
@@ -1880,7 +1880,7 @@ pub neo4j::Neo4jError::InvalidConfig::message: alloc::string::String
 #[non_exhaustive] pub neo4j::Neo4jError::ProtocolError
 pub neo4j::Neo4jError::ProtocolError::message: alloc::string::String
 #[non_exhaustive] pub neo4j::Neo4jError::ServerError
-pub neo4j::Neo4jError::ServerError::error: neo4j::error::ServerError
+pub neo4j::Neo4jError::ServerError::error: alloc::boxed::Box<neo4j::error::ServerError>
 #[non_exhaustive] pub neo4j::Neo4jError::Timeout
 pub neo4j::Neo4jError::Timeout::message: alloc::string::String
 #[non_exhaustive] pub neo4j::Neo4jError::UserCallback

--- a/testkit_backend/Cargo.toml
+++ b/testkit_backend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "testkit_backend"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/testkit_backend/src/testkit_backend.rs
+++ b/testkit_backend/src/testkit_backend.rs
@@ -54,7 +54,7 @@ type TestKitResult = TestKitResultT<()>;
 
 pub(super) fn start_server() {
     let listener = TcpListener::bind(ADDRESS).unwrap();
-    println!("Listening on {}", ADDRESS);
+    println!("Listening on {ADDRESS}");
     for stream in listener.incoming() {
         logging::clear_log();
         match stream {
@@ -184,7 +184,7 @@ impl BackendIo {
                 .reader
                 .read_line(&mut line)
                 .map_err(|e| TestKitError::FatalError {
-                    error: format!("{:?}", e),
+                    error: format!("{e:?}"),
                 })?;
             if read == 0 {
                 return Err(TestKitError::FatalError {

--- a/testkit_backend/src/testkit_backend.rs
+++ b/testkit_backend/src/testkit_backend.rs
@@ -68,7 +68,7 @@ pub(super) fn start_server() {
                 }
             }
             Err(err) => {
-                warn!("Connection failed {:?}", err);
+                warn!("Connection failed {err:?}");
             }
         }
     }

--- a/testkit_backend/src/testkit_backend/auth.rs
+++ b/testkit_backend/src/testkit_backend/auth.rs
@@ -54,15 +54,14 @@ impl TestKitAuthManagers {
                 Request::BasicAuthTokenProviderCompleted { request_id, auth } => {
                     if request_id != id {
                         return Err(Box::new(TestKitError::backend_err(format!(
-                            "expected BasicAuthTokenProviderCompleted for id {}, received for {}",
-                            id, request_id
+                            "expected BasicAuthTokenProviderCompleted for id {id}, \
+                             received for {request_id}"
                         ))));
                     }
                     Ok(auth.into())
                 }
                 _ => Err(Box::new(TestKitError::backend_err(format!(
-                    "expected BasicAuthTokenProviderCompleted, received {:?}",
-                    request
+                    "expected BasicAuthTokenProviderCompleted, received {request:?}"
                 )))),
             }
         }));
@@ -92,8 +91,8 @@ impl TestKitAuthManagers {
                 Request::BearerAuthTokenProviderCompleted { request_id, auth } => {
                     if request_id != id {
                         return Err(Box::new(TestKitError::backend_err(format!(
-                            "expected BearerAuthTokenProviderCompleted for id {}, received for {}",
-                            id, request_id
+                            "expected BearerAuthTokenProviderCompleted for id {id}, \
+                             received for {request_id}"
                         ))));
                     }
                     let AuthTokenAndExpiration::AuthTokenAndExpiration {
@@ -119,8 +118,7 @@ impl TestKitAuthManagers {
                     Ok((auth.into(), expires))
                 }
                 _ => Err(Box::new(TestKitError::backend_err(format!(
-                    "expected BearerAuthTokenProviderCompleted, received {:?}",
-                    request
+                    "expected BearerAuthTokenProviderCompleted, received {request:?}"
                 )))),
             }
         }));
@@ -168,15 +166,14 @@ impl AuthManager for TestKitCustomAuthManager {
             Request::AuthTokenManagerGetAuthCompleted { request_id, auth } => {
                 if request_id != id {
                     return Err(Box::new(TestKitError::backend_err(format!(
-                        "expected AuthTokenManagerGetAuthCompleted for id {}, received for {}",
-                        id, request_id
+                        "expected AuthTokenManagerGetAuthCompleted for id {id}, \
+                         received for {request_id}"
                     ))));
                 }
                 Ok(Arc::new(auth.into()))
             }
             _ => Err(Box::new(TestKitError::backend_err(format!(
-                "expected AuthTokenManagerGetAuthCompleted, received {:?}",
-                request
+                "expected AuthTokenManagerGetAuthCompleted, received {request:?}"
             )))),
         }
     }
@@ -206,15 +203,14 @@ impl AuthManager for TestKitCustomAuthManager {
             } => {
                 if request_id != id {
                     return Err(Box::new(TestKitError::backend_err(format!(
-                        "expected AuthTokenManagerHandleSecurityExceptionCompleted for id {}, received for {}",
-                        id, request_id
+                        "expected AuthTokenManagerHandleSecurityExceptionCompleted for id {id}, \
+                         received for {request_id}"
                     ))));
                 }
                 Ok(handled)
             }
             _ => Err(Box::new(TestKitError::backend_err(format!(
-                "expected AuthTokenManagerGetAuthCompleted, received {:?}",
-                request
+                "expected AuthTokenManagerGetAuthCompleted, received {request:?}"
             )))),
         }
     }

--- a/testkit_backend/src/testkit_backend/backend_id.rs
+++ b/testkit_backend/src/testkit_backend/backend_id.rs
@@ -39,7 +39,7 @@ impl FromStr for BackendId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         u64::from_str(s)
-            .map_err(|err| format!("Invalid BackendId: {}", err))
+            .map_err(|err| format!("Invalid BackendId: {err}"))
             .map(BackendId)
     }
 }

--- a/testkit_backend/src/testkit_backend/bookmarks.rs
+++ b/testkit_backend/src/testkit_backend/bookmarks.rs
@@ -79,15 +79,14 @@ fn make_supplier_fn(
             } => {
                 if request_id != id {
                     return Err(Box::new(TestKitError::backend_err(format!(
-                        "expected BookmarksSupplierCompleted for id {}, received for {}",
-                        id, request_id
+                        "expected BookmarksSupplierCompleted for id {id}, \
+                         received for {request_id}"
                     ))));
                 }
                 Ok(Arc::new(Bookmarks::from_raw(bookmarks)))
             }
             _ => Err(Box::new(TestKitError::backend_err(format!(
-                "expected BookmarksSupplierCompleted, received {:?}",
-                request
+                "expected BookmarksSupplierCompleted, received {request:?}"
             )))),
         }
     }
@@ -115,15 +114,14 @@ fn make_consumer_fn(
             Request::BookmarksConsumerCompleted { request_id } => {
                 if request_id != id {
                     return Err(Box::new(TestKitError::backend_err(format!(
-                        "expected BookmarksConsumerCompleted for id {}, received for {}",
-                        id, request_id
+                        "expected BookmarksConsumerCompleted for id {id}, \
+                         received for {request_id}"
                     ))));
                 }
                 Ok(())
             }
             _ => Err(Box::new(TestKitError::backend_err(format!(
-                "expected BookmarksConsumerCompleted, received {:?}",
-                request
+                "expected BookmarksConsumerCompleted, received {request:?}"
             )))),
         }
     }

--- a/testkit_backend/src/testkit_backend/cypher_value.rs
+++ b/testkit_backend/src/testkit_backend/cypher_value.rs
@@ -559,8 +559,7 @@ impl TryFrom<ValueSend> for CypherValue {
             ValueSend::DateTimeFixed(value) => date_time_fixed_to_cypher_value(value),
             _ => {
                 return Err(TestKitError::backend_err(format!(
-                    "Failed to serialize to json: {:?}",
-                    v,
+                    "Failed to serialize to json: {v:?}",
                 )))
             }
         })
@@ -609,7 +608,7 @@ impl TryFrom<ConvertableValueSend> for JsonValue {
             ValueSend::Map(v) => JsonValue::Object(try_into_json_map(
                 v.into_iter().map(|(k, v)| (k, ConvertableValueSend(v))),
             )?),
-            _ => return Err(format!("Failed to serialize to json: {:?}", v)),
+            _ => return Err(format!("Failed to serialize to json: {v:?}")),
         })
     }
 }
@@ -906,7 +905,7 @@ impl TryFrom<ConvertableValueReceive> for JsonValue {
             ValueReceive::Map(v) => JsonValue::Object(try_into_json_map(
                 v.into_iter().map(|(k, v)| (k, ConvertableValueReceive(v))),
             )?),
-            _ => return Err(format!("Failed to serialize to json: {:?}", v)),
+            _ => return Err(format!("Failed to serialize to json: {v:?}")),
         })
     }
 }

--- a/testkit_backend/src/testkit_backend/driver_holder.rs
+++ b/testkit_backend/src/testkit_backend/driver_holder.rs
@@ -235,10 +235,7 @@ impl DriverHolder {
         self.tx_req.send(args.into()).unwrap();
         match self.rx_res.recv().unwrap() {
             CommandResult::RollbackTransaction(result) => result,
-            res => panic!(
-                "expected CommandResult::RollbackTransaction, found {:?}",
-                res
-            ),
+            res => panic!("expected CommandResult::RollbackTransaction, found {res:?}"),
         }
     }
 
@@ -356,8 +353,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             AutoCommitResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),
@@ -376,8 +372,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             TransactionFunctionResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),
@@ -396,8 +391,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             RetryablePositiveResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),
@@ -416,8 +410,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             RetryableNegativeResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),
@@ -436,8 +429,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             BeginTransactionResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),
@@ -575,8 +567,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             BeginTransactionResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),
@@ -604,8 +595,7 @@ impl DriverHolderRunner {
                         break 'arm Some(
                             CloseSessionResult {
                                 result: Err(TestKitError::backend_err(format!(
-                                    "Session id {} not found in driver",
-                                    session_id
+                                    "Session id {session_id} not found in driver"
                                 ))),
                             }
                             .into(),

--- a/testkit_backend/src/testkit_backend/errors.rs
+++ b/testkit_backend/src/testkit_backend/errors.rs
@@ -90,7 +90,7 @@ impl From<TestKitDriverError> for TestKitError {
 
 impl Display for TestKitError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -161,29 +161,29 @@ impl From<UserCallbackError> for TestKitError {
             UserCallbackError::Resolver(err) => match err.downcast::<Self>() {
                 Ok(err) => *err,
                 Err(err) => TestKitError::BackendError {
-                    msg: format!("unexpected resolver error: {}", err),
+                    msg: format!("unexpected resolver error: {err}"),
                 },
             },
             UserCallbackError::AuthManager(err) => match err.downcast::<Self>() {
                 Ok(err) => *err,
                 Err(err) => TestKitError::BackendError {
-                    msg: format!("unexpected auth manager error: {}", err),
+                    msg: format!("unexpected auth manager error: {err}"),
                 },
             },
             UserCallbackError::BookmarkManagerGet(err) => match err.downcast::<Self>() {
                 Ok(err) => *err,
                 Err(err) => TestKitError::BackendError {
-                    msg: format!("unexpected bookmark manager get error: {}", err),
+                    msg: format!("unexpected bookmark manager get error: {err}"),
                 },
             },
             UserCallbackError::BookmarkManagerUpdate(err) => match err.downcast::<Self>() {
                 Ok(err) => *err,
                 Err(err) => TestKitError::BackendError {
-                    msg: format!("unexpected bookmark manager update error: {}", err),
+                    msg: format!("unexpected bookmark manager update error: {err}"),
                 },
             },
             _ => TestKitError::BackendError {
-                msg: format!("unhandled user callback error type: {}", value),
+                msg: format!("unhandled user callback error type: {value}"),
             },
         }
     }
@@ -195,29 +195,29 @@ impl From<&UserCallbackError> for TestKitError {
             UserCallbackError::Resolver(err) => match err.downcast_ref::<Self>() {
                 Some(err) => err.clone(),
                 None => TestKitError::BackendError {
-                    msg: format!("unexpected resolver error: {}", err),
+                    msg: format!("unexpected resolver error: {err}"),
                 },
             },
             UserCallbackError::AuthManager(err) => match err.downcast_ref::<Self>() {
                 Some(err) => err.clone(),
                 None => TestKitError::BackendError {
-                    msg: format!("unexpected auth manager error: {}", err),
+                    msg: format!("unexpected auth manager error: {err}"),
                 },
             },
             UserCallbackError::BookmarkManagerGet(err) => match err.downcast_ref::<Self>() {
                 Some(err) => err.clone(),
                 None => TestKitError::BackendError {
-                    msg: format!("unexpected bookmark manager get error: {}", err),
+                    msg: format!("unexpected bookmark manager get error: {err}"),
                 },
             },
             UserCallbackError::BookmarkManagerUpdate(err) => match err.downcast_ref::<Self>() {
                 Some(err) => err.clone(),
                 None => TestKitError::BackendError {
-                    msg: format!("unexpected bookmark manager update error: {}", err),
+                    msg: format!("unexpected bookmark manager update error: {err}"),
                 },
             },
             _ => TestKitError::BackendError {
-                msg: format!("unhandled user callback error type: {}", value),
+                msg: format!("unhandled user callback error type: {value}"),
             },
         }
     }
@@ -333,7 +333,7 @@ impl TestKitError {
         match res {
             Ok(ok) => Ok(ok),
             Err(err) => Err(Self::FatalError {
-                error: format!("{:?}", err),
+                error: format!("{err:?}"),
             }),
         }
     }

--- a/testkit_backend/src/testkit_backend/errors.rs
+++ b/testkit_backend/src/testkit_backend/errors.rs
@@ -126,7 +126,7 @@ impl From<Neo4jError> for TestKitError {
                     diagnostic_record,
                     cause,
                     ..
-                } = error;
+                } = *error;
                 TestKitDriverError {
                     error_type: String::from("ServerError"),
                     msg: message,

--- a/testkit_backend/src/testkit_backend/requests.rs
+++ b/testkit_backend/src/testkit_backend/requests.rs
@@ -645,8 +645,7 @@ fn load_notification_filter(
             "WARNING" => MinimumSeverity::Warning,
             _ => {
                 return Err(TestKitError::backend_err(format!(
-                    "unknown minimum notification severity: {severity:?}",
-                    severity = severity
+                    "unknown minimum notification severity: {severity:?}"
                 )))
             }
         }),
@@ -668,8 +667,7 @@ fn load_notification_filter(
                         "SCHEMA" => DisabledCategory::Schema,
                         _ => {
                             return Err(TestKitError::backend_err(format!(
-                                "unknown disabled notification category: {cat:?}",
-                                cat = category
+                                "unknown disabled notification category: {category:?}"
                             )))
                         }
                     })
@@ -694,8 +692,7 @@ fn load_notification_filter(
                         "SCHEMA" => DisabledClassification::Schema,
                         _ => {
                             return Err(TestKitError::backend_err(format!(
-                                "unknown disabled notification classification: {cls:?}",
-                                cls = classification
+                                "unknown disabled notification classification: {classification:?}"
                             )))
                         }
                     })
@@ -792,8 +789,7 @@ impl Request {
             Request::FakeTimeUninstall { .. } => self.fake_time_uninstall(backend)?,
             _ => {
                 return Err(TestKitError::backend_err(format!(
-                    "Unhandled request {:?}",
-                    self
+                    "Unhandled request {self:?}"
                 )))
             }
         }
@@ -802,8 +798,7 @@ impl Request {
 
     fn unexpected_resolution(self) -> TestKitResult {
         Err(TestKitError::backend_err(format!(
-            "Resolution {:?} not expected (the backend didn't ask for it).",
-            self
+            "Resolution {self:?} not expected (the backend didn't ask for it)."
         )))
     }
 

--- a/testkit_backend/src/testkit_backend/resolver.rs
+++ b/testkit_backend/src/testkit_backend/resolver.rs
@@ -69,16 +69,15 @@ impl TestKitResolver {
             } => {
                 if request_id != id {
                     return Err(Box::new(TestKitError::backend_err(format!(
-                        "expected ResolverResolutionCompleted for id {}, received for {}",
-                        id, request_id
+                        "expected ResolverResolutionCompleted for id {id}, \
+                         received for {request_id}"
                     ))));
                 }
                 addresses
             }
             _ => {
                 return Err(Box::new(TestKitError::backend_err(format!(
-                    "expected ResolverResolutionCompleted, received {:?}",
-                    request
+                    "expected ResolverResolutionCompleted, received {request:?}"
                 ))))
             }
         };
@@ -108,8 +107,8 @@ impl TestKitResolver {
             } => {
                 if request_id != id {
                     return testkit_to_io_error(Err(TestKitError::backend_err(format!(
-                        "expected DomainNameResolutionCompleted for id {}, received for {}",
-                        id, request_id
+                        "expected DomainNameResolutionCompleted for id {id}, \
+                         received for {request_id}"
                     ))));
                 }
                 addresses

--- a/testkit_backend/src/testkit_backend/session_holder.rs
+++ b/testkit_backend/src/testkit_backend/session_holder.rs
@@ -1292,7 +1292,7 @@ impl RecordBuffer {
                     .expect("result stream exhausted above => cannot fail on consume")
                     .map(Arc::new);
             }
-            RecordBuffer::Transaction { .. } => {
+            RecordBuffer::Transaction => {
                 panic!("cannot buffer record stream in transaction")
             }
         }
@@ -1314,7 +1314,7 @@ impl RecordBuffer {
                     Err(e) => records.push_back(Err(Arc::new(e))),
                 }
             }
-            RecordBuffer::Transaction { .. } => {
+            RecordBuffer::Transaction => {
                 panic!("cannot consume record stream in transaction")
             }
         }
@@ -1335,7 +1335,7 @@ impl RecordBuffer {
                         .and_then(|r| r.map(TryInto::try_into).transpose())
                 }
             }
-            RecordBuffer::Transaction { .. } => Err(result_out_of_scope_error()),
+            RecordBuffer::Transaction => Err(result_out_of_scope_error()),
         }
     }
 
@@ -1370,7 +1370,7 @@ impl RecordBuffer {
                     }
                 }
             }
-            RecordBuffer::Transaction { .. } => Err(result_out_of_scope_error()),
+            RecordBuffer::Transaction => Err(result_out_of_scope_error()),
         }
     }
 

--- a/testkit_backend/src/testkit_backend/session_holder.rs
+++ b/testkit_backend/src/testkit_backend/session_holder.rs
@@ -142,10 +142,7 @@ impl SessionHolder {
         self.tx_req.send(args.into()).unwrap();
         match self.rx_res.recv().unwrap() {
             CommandResult::RollbackTransaction(result) => result,
-            res => panic!(
-                "expected CommandResult::RollbackTransaction, found {:?}",
-                res
-            ),
+            res => panic!("expected CommandResult::RollbackTransaction, found {res:?}"),
         }
     }
 


### PR DESCRIPTION
Hello. When building this crate clippy emits some warnings. 

One of them is about the size of the `neo4j::Result` type.
Neo4jError has a `ServerError` variant that takes up a lot of space. This forces all Neo4jErrors, and thus 
all `neo4j::Result`s to be huge, which can impact performance. 
The suggested solution is to wrap the `ServerError` on a `Box`. This reduces the size of a 
`Neo4jError` from 184 bytes to 40 bytes (on my computer).

The other warnings were less important. Two of them were more of a style lint, the other was about an 
unnecessary use of the format! macro.

P.D: This crate is amazing. I've used it for a school project, thank you!! :)